### PR TITLE
refactor: explicitly handle errors in the updateChecker function

### DIFF
--- a/CodePush.js
+++ b/CodePush.js
@@ -90,14 +90,19 @@ async function checkForUpdate(deploymentKey = null, handleBinaryVersionMismatchC
           log(`An error has occurred at update checker : ${error.stack}`);
           if (sharedCodePushOptions.fallbackToAppCenter) {
             return await sdk.queryUpdateWithCurrentPackage(queryPackage);
+          } else {
+            // update will not happen
+            return undefined;
           }
         }
       })()
       : await sdk.queryUpdateWithCurrentPackage(queryPackage);
 
-  const fileName = update && typeof update.downloadUrl === 'string' ? update.downloadUrl.split('/').pop() : null;
-  if (sharedCodePushOptions.bundleHost && fileName) {
-    update.downloadUrl = sharedCodePushOptions.bundleHost + fileName;
+  if (sharedCodePushOptions.bundleHost && update) {
+    const fileName = typeof update.downloadUrl === 'string' ? update.downloadUrl.split('/').pop() : null;
+    if (fileName) {
+      update.downloadUrl = sharedCodePushOptions.bundleHost + fileName;
+    }
   }
 
   /*


### PR DESCRIPTION
closes #3 

**as-is**
If the `updateChecker` option was used, the catch block did not explicitly throw an error.
However, the subsequent code is guarding against undefined references by validating the `update` value.
Therefore, the existing code is not causing a problem and is handling it so that the update is not executed.

**to-be**
This PR improves the way error handling is expressed in the code.