### PR TITLE
Implement CodePush Bundle Generation Command

### DIFF
--- a/cli/commands/bundleCodePush.js
+++ b/cli/commands/bundleCodePush.js
@@ -1,0 +1,39 @@
+import { prepareToBundleJS } from '../functions/prepareToBundleJS';
+import { runReactNativeBundleCommand } from '../functions/runReactNativeBundleCommand';
+import { getReactTempDir } from '../functions/getReactTempDir';
+import { runHermesEmitBinaryCommand } from '../functions/runHermesEmitBinaryCommand';
+import { makeCodePushBundle } from '../functions/makeCodePushBundle';
+
+const platform = 'ios' ;
+
+async function runBundleCodePush() {
+
+    // TODO: Make it configurable via command line arguments
+    const OUTPUT_PATH = 'build' ;
+    const CONTENTS_PATH = `${OUTPUT_PATH}/CodePush` ;
+    const BUNDLE_NAME = platform === 'ios' ? 'main.jsbundle' : 'index.android.bundle';
+    const SOURCEMAP_OUTPUT = `${OUTPUT_PATH}/${BUNDLE_NAME}.map` ;
+
+    prepareToBundleJS({ deleteDirs: [OUTPUT_PATH, getReactTempDir()], makeDir: CONTENTS_PATH });
+
+    runReactNativeBundleCommand(
+      BUNDLE_NAME,
+      CONTENTS_PATH,
+      platform,
+      SOURCEMAP_OUTPUT,
+    );
+    console.log('log: JS bundling complete');
+
+    await runHermesEmitBinaryCommand(
+      BUNDLE_NAME,
+      CONTENTS_PATH,
+      SOURCEMAP_OUTPUT,
+    );
+    console.log('log: Hermes compilation complete');
+
+    const { bundleFileName, packageHash } = await makeCodePushBundle(CONTENTS_PATH);
+    console.log(`log: CodePush bundle created (file name: ${bundleFileName})`);
+
+
+    // TODO: Output packageHash and file name - Required when creating ReleaseHistoryInterface data
+}

--- a/cli/commands/bundleCodePush.js
+++ b/cli/commands/bundleCodePush.js
@@ -1,8 +1,8 @@
-import { prepareToBundleJS } from '../functions/prepareToBundleJS';
-import { runReactNativeBundleCommand } from '../functions/runReactNativeBundleCommand';
-import { getReactTempDir } from '../functions/getReactTempDir';
-import { runHermesEmitBinaryCommand } from '../functions/runHermesEmitBinaryCommand';
-import { makeCodePushBundle } from '../functions/makeCodePushBundle';
+const { prepareToBundleJS } = require('../functions/prepareToBundleJS');
+const { runReactNativeBundleCommand } = require('../functions/runReactNativeBundleCommand');
+const { getReactTempDir } = require('../functions/getReactTempDir');
+const { runHermesEmitBinaryCommand } = require('../functions/runHermesEmitBinaryCommand');
+const { makeCodePushBundle } = require('../functions/makeCodePushBundle');
 
 const platform = 'ios' ;
 
@@ -37,3 +37,5 @@ async function runBundleCodePush() {
 
     // TODO: Output packageHash and file name - Required when creating ReleaseHistoryInterface data
 }
+
+module.exports = { runBundleCodePush };

--- a/cli/functions/getReactTempDir.js
+++ b/cli/functions/getReactTempDir.js
@@ -2,13 +2,15 @@
  * code based on appcenter-cli
  */
 
-import os from 'os';
+const os = require('os');
 
 /**
  * Return the path of the temporary directory for react-native bundling
  *
  * @return {string}
  */
-export function getReactTempDir() {
+function getReactTempDir() {
     return `${os.tmpdir()}/react-*`;
 }
+
+module.exports = { getReactTempDir };

--- a/cli/functions/getReactTempDir.js
+++ b/cli/functions/getReactTempDir.js
@@ -1,0 +1,14 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import os from 'os';
+
+/**
+ * Return the path of the temporary directory for react-native bundling
+ *
+ * @return {string}
+ */
+export function getReactTempDir() {
+    return `${os.tmpdir()}/react-*`;
+}

--- a/cli/functions/makeCodePushBundle.js
+++ b/cli/functions/makeCodePushBundle.js
@@ -1,0 +1,25 @@
+import { randomUUID } from 'crypto';
+import path from 'path';
+import shell from 'shelljs';
+import zip from '../utils/zip';
+import {generatePackageHashFromDirectory} from '../utils/hash-utils';
+
+/**
+ * Create a CodePush bundle file and return the information.
+ *
+ * @param contentsPath {string} The directory path containing the contents to be made into a CodePush bundle (usually the 'build/CodePush' directory))
+ * @return {Promise<{ bundleFileName: string, packageHash: string }>}
+ */
+export async function makeCodePushBundle(contentsPath) {
+    const updateContentsZipPath = await zip(contentsPath);
+
+    const bundleFileName = randomUUID();
+    shell.mv(updateContentsZipPath, `./${bundleFileName}`);
+
+    const packageHash = await generatePackageHashFromDirectory(contentsPath, path.join(contentsPath, '..'));
+
+    return {
+        bundleFileName: bundleFileName,
+        packageHash: packageHash,
+    };
+}

--- a/cli/functions/makeCodePushBundle.js
+++ b/cli/functions/makeCodePushBundle.js
@@ -1,8 +1,8 @@
-import { randomUUID } from 'crypto';
-import path from 'path';
-import shell from 'shelljs';
-import zip from '../utils/zip';
-import {generatePackageHashFromDirectory} from '../utils/hash-utils';
+const { randomUUID } = require('crypto');
+const path = require('path');
+const shell = require('shelljs');
+const zip = require('../utils/zip');
+const {generatePackageHashFromDirectory} = require('../utils/hash-utils');
 
 /**
  * Create a CodePush bundle file and return the information.
@@ -10,7 +10,7 @@ import {generatePackageHashFromDirectory} from '../utils/hash-utils';
  * @param contentsPath {string} The directory path containing the contents to be made into a CodePush bundle (usually the 'build/CodePush' directory))
  * @return {Promise<{ bundleFileName: string, packageHash: string }>}
  */
-export async function makeCodePushBundle(contentsPath) {
+async function makeCodePushBundle(contentsPath) {
     const updateContentsZipPath = await zip(contentsPath);
 
     const bundleFileName = randomUUID();
@@ -23,3 +23,5 @@ export async function makeCodePushBundle(contentsPath) {
         packageHash: packageHash,
     };
 }
+
+module.exports = { makeCodePushBundle };

--- a/cli/functions/prepareToBundleJS.js
+++ b/cli/functions/prepareToBundleJS.js
@@ -1,0 +1,10 @@
+import shell from 'shelljs';
+
+/**
+ * @param deleteDirs {string[]} Directories to delete
+ * @param makeDir {string} Directory path to create
+ */
+export function prepareToBundleJS({ deleteDirs, makeDir }) {
+    shell.rm('-rf', deleteDirs);
+    shell.mkdir('-p', makeDir);
+}

--- a/cli/functions/prepareToBundleJS.js
+++ b/cli/functions/prepareToBundleJS.js
@@ -1,10 +1,12 @@
-import shell from 'shelljs';
+const shell = require('shelljs');
 
 /**
  * @param deleteDirs {string[]} Directories to delete
  * @param makeDir {string} Directory path to create
  */
-export function prepareToBundleJS({ deleteDirs, makeDir }) {
+function prepareToBundleJS({ deleteDirs, makeDir }) {
     shell.rm('-rf', deleteDirs);
     shell.mkdir('-p', makeDir);
 }
+
+module.exports = { prepareToBundleJS };

--- a/cli/functions/runHermesEmitBinaryCommand.js
+++ b/cli/functions/runHermesEmitBinaryCommand.js
@@ -1,0 +1,211 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import childProcess from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import shell from 'shelljs';
+
+/**
+ * Run Hermes compile CLI command
+ *
+ * @param bundleName {string} JS bundle file name
+ * @param outputPath {string} Path to output .hbc file
+ * @param sourcemapOutput {string} Path to output sourcemap file (Warning: if sourcemapOutput points to the outputPath, the sourcemap will be included in the CodePush bundle and increase the deployment size)
+ * @param extraHermesFlags {string[]} Additional options to pass to `hermesc` command
+ * @return {Promise<void>}
+ */
+export async function runHermesEmitBinaryCommand(
+    bundleName,
+    outputPath,
+    sourcemapOutput,
+    extraHermesFlags = [],
+) {
+    /**
+     * @type {string[]}
+     */
+    const hermesArgs = [
+        '-emit-binary',
+        '-out',
+        path.join(outputPath, bundleName + '.hbc'),
+        path.join(outputPath, bundleName),
+        ...extraHermesFlags,
+    ];
+    if (sourcemapOutput) {
+        hermesArgs.push('-output-source-map');
+    }
+
+    console.log('Converting JS bundle to byte code via Hermes, running command:\n');
+
+    return new Promise((resolve, reject) => {
+        try {
+            const hermesCommand = getHermesCommand();
+
+            const disableAllWarningsArg = '-w';
+            shell.exec(`${hermesCommand} ${hermesArgs.join(' ')} ${disableAllWarningsArg}`);
+
+            // Copy HBC bundle to overwrite JS bundle
+            const source = path.join(outputPath, bundleName + '.hbc');
+            const destination = path.join(outputPath, bundleName);
+            shell.cp(source, destination);
+            shell.rm(source);
+            resolve();
+        } catch (e) {
+            reject(e);
+        }
+    }).then(() => {
+        if (!sourcemapOutput) {
+            // skip source map compose if source map is not enabled
+            return;
+        }
+
+        // compose-source-maps.js file path
+        const composeSourceMapsPath = getComposeSourceMapsPath();
+        if (composeSourceMapsPath === null) {
+            throw new Error('react-native compose-source-maps.js scripts is not found');
+        }
+
+        const jsCompilerSourceMapFile = path.join(outputPath, bundleName + '.hbc' + '.map');
+        if (!fs.existsSync(jsCompilerSourceMapFile)) {
+            throw new Error(`sourcemap file ${jsCompilerSourceMapFile} is not found`);
+        }
+
+        return new Promise((resolve, reject) => {
+            const composeSourceMapsArgs = [
+                composeSourceMapsPath,
+                sourcemapOutput,
+                jsCompilerSourceMapFile,
+                '-o',
+                sourcemapOutput,
+            ];
+            const composeSourceMapsProcess = childProcess.spawn('node', composeSourceMapsArgs);
+            console.log(`${composeSourceMapsPath} ${composeSourceMapsArgs.join(' ')}`);
+
+            composeSourceMapsProcess.stdout.on('data', (data) => {
+                console.log(data.toString().trim());
+            });
+
+            composeSourceMapsProcess.stderr.on('data', (data) => {
+                console.error(data.toString().trim());
+            });
+
+            composeSourceMapsProcess.on('close', (exitCode, signal) => {
+                if (exitCode !== 0) {
+                    reject(new Error(`"compose-source-maps" command failed (exitCode=${exitCode}, signal=${signal}).`));
+                }
+
+                // Delete the HBC sourceMap, otherwise it will be included in 'code-push' bundle as well
+                fs.unlink(jsCompilerSourceMapFile, (err) => {
+                    if (err != null) {
+                        console.error(err);
+                        reject(err);
+                    }
+
+                    resolve();
+                });
+            });
+        });
+    });
+}
+
+/**
+ * @return {string}
+ */
+function getHermesCommand() {
+    /**
+     * @type {(file: string) => boolean}
+     */
+    const fileExists = (file) => {
+        try {
+            return fs.statSync(file).isFile();
+        } catch (e) {
+            return false;
+        }
+    };
+    // Hermes is bundled with react-native since 0.69
+    const bundledHermesEngine = path.join(
+        getReactNativePackagePath(),
+        'sdks',
+        'hermesc',
+        getHermesOSBin(),
+        getHermesOSExe(),
+    );
+    if (fileExists(bundledHermesEngine)) {
+        return bundledHermesEngine;
+    }
+    throw new Error('Hermes engine binary not found. Please upgrade to react-native 0.69 or later');
+}
+
+/**
+ * @return {string}
+ */
+function getHermesOSBin() {
+    switch (process.platform) {
+        case 'win32':
+            return 'win64-bin';
+        case 'darwin':
+            return 'osx-bin';
+        case 'freebsd':
+        case 'linux':
+        case 'sunos':
+        default:
+            return 'linux64-bin';
+    }
+}
+
+/**
+ * @return {string}
+ */
+function getHermesOSExe() {
+    const hermesExecutableName = 'hermesc';
+    switch (process.platform) {
+        case 'win32':
+            return hermesExecutableName + '.exe';
+        default:
+            return hermesExecutableName;
+    }
+}
+
+/**
+ * @return {string | null}
+ */
+function getComposeSourceMapsPath() {
+    // detect if compose-source-maps.js script exists
+    const composeSourceMaps = path.join(getReactNativePackagePath(), 'scripts', 'compose-source-maps.js');
+    if (fs.existsSync(composeSourceMaps)) {
+        return composeSourceMaps;
+    }
+    return null;
+}
+
+/**
+ * @return {string}
+ */
+function getReactNativePackagePath() {
+    const result = childProcess.spawnSync('node', [
+        '--print',
+        "require.resolve('react-native/package.json')",
+    ]);
+    const packagePath = path.dirname(result.stdout.toString());
+    if (result.status === 0 && directoryExistsSync(packagePath)) {
+        return packagePath;
+    }
+
+    return path.join('node_modules', 'react-native');
+}
+
+/**
+ * @param dirname {string}
+ * @return {boolean}
+ */
+function directoryExistsSync(dirname) {
+    try {
+        return fs.statSync(dirname).isDirectory();
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            throw err;
+        }
+    }
+    return false;
+}

--- a/cli/functions/runHermesEmitBinaryCommand.js
+++ b/cli/functions/runHermesEmitBinaryCommand.js
@@ -2,10 +2,10 @@
  * code based on appcenter-cli
  */
 
-import childProcess from 'child_process';
-import fs from 'fs';
-import path from 'path';
-import shell from 'shelljs';
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const shell = require('shelljs');
 
 /**
  * Run Hermes compile CLI command
@@ -16,7 +16,7 @@ import shell from 'shelljs';
  * @param extraHermesFlags {string[]} Additional options to pass to `hermesc` command
  * @return {Promise<void>}
  */
-export async function runHermesEmitBinaryCommand(
+async function runHermesEmitBinaryCommand(
     bundleName,
     outputPath,
     sourcemapOutput,
@@ -209,3 +209,5 @@ function directoryExistsSync(dirname) {
     }
     return false;
 }
+
+module.exports = { runHermesEmitBinaryCommand };

--- a/cli/functions/runReactNativeBundleCommand.js
+++ b/cli/functions/runReactNativeBundleCommand.js
@@ -1,0 +1,57 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import path from 'path';
+import shell from 'shelljs';
+
+/**
+ * Run `react-native bundle` CLI command
+ *
+ * @param bundleName {string} JS bundle file name
+ * @param entryFile {string} App code entry file name (default: index.ts)
+ * @param outputPath {string} Path to output JS bundle file and assets
+ * @param platform {string} Platform (ios | android)
+ * @param sourcemapOutput {string} Path to output sourcemap file (Warning: if sourcemapOutput points to the outputPath, the sourcemap will be included in the CodePush bundle and increase the deployment size)
+ * @param extraBundlerOptions {string[]} Additional options to pass to `react-native bundle` command
+ * @return {void}
+ */
+export function runReactNativeBundleCommand(
+    bundleName,
+    outputPath,
+    platform,
+    sourcemapOutput,
+    entryFile = 'index.ts',
+    extraBundlerOptions = [],
+) {
+    /**
+     * @return {string}
+     */
+    function getCliPath() {
+        return path.join('node_modules', '.bin', 'react-native');
+    }
+
+    /**
+     * @type {string[]}
+     */
+    const reactNativeBundleArgs = [
+        'bundle',
+        '--assets-dest',
+        outputPath,
+        '--bundle-output',
+        path.join(outputPath, bundleName),
+        '--dev',
+        'false',
+        '--entry-file',
+        entryFile,
+        '--platform',
+        platform,
+        '--sourcemap-output',
+        sourcemapOutput,
+        ...extraBundlerOptions,
+    ];
+
+    console.log('Running "react-native bundle" command:\n');
+
+    shell.exec(`${getCliPath()} ${reactNativeBundleArgs.join(' ')}`);
+}

--- a/cli/functions/runReactNativeBundleCommand.js
+++ b/cli/functions/runReactNativeBundleCommand.js
@@ -2,8 +2,8 @@
  * code based on appcenter-cli
  */
 
-import path from 'path';
-import shell from 'shelljs';
+const path = require('path');
+const shell = require('shelljs');
 
 /**
  * Run `react-native bundle` CLI command
@@ -16,7 +16,7 @@ import shell from 'shelljs';
  * @param extraBundlerOptions {string[]} Additional options to pass to `react-native bundle` command
  * @return {void}
  */
-export function runReactNativeBundleCommand(
+function runReactNativeBundleCommand(
     bundleName,
     outputPath,
     platform,
@@ -55,3 +55,5 @@ export function runReactNativeBundleCommand(
 
     shell.exec(`${getCliPath()} ${reactNativeBundleArgs.join(' ')}`);
 }
+
+module.exports = { runReactNativeBundleCommand };

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-const { program } = require("commander");
+const { program, Option } = require("commander");
 const shell = require("shelljs");
 const { showLogo } = require("./utils/showLogo");
 const { findAndReadConfigFile } = require("./utils/fsUtils");
+const { runBundleCodePush } = require('./commands/bundleCodePush')
 
 shell.set("-e");
 shell.set("-v");
@@ -15,6 +16,31 @@ program
   .action(async () => {
     showLogo();
     const config = findAndReadConfigFile(process.cwd());
+
+    // TODO: implement interactive mode
+  });
+
+program.command('bundle')
+  .description('Creating CodePush bundle file. (assumes that Hermes is enabled.)')
+  .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
+  .option('-o, --output-path <string>', 'path to output root directory', 'build')
+  .option('-e, --entry-file <string>', 'path to JS/TS entry file', 'index.ts')
+  .option('-b, --bundle-name <string>', 'bundle file name (default-ios: "main.jsbundle" / default-android: "index.android.bundle")')
+  /**
+   * @param {Object} options
+   * @param {string} options.platform
+   * @param {string} options.outputPath
+   * @param {string} options.entryFile
+   * @param {string} options.bundleName
+   * @return {void}
+   */
+  .action((options) => {
+    runBundleCodePush(
+      options.platform,
+      options.outputPath,
+      options.entryFile,
+      options.bundleName,
+    )
   });
 
 program.parse();

--- a/cli/utils/file-utils.js
+++ b/cli/utils/file-utils.js
@@ -2,14 +2,14 @@
  * code based on appcenter-cli
  */
 
-import * as fs from 'fs';
+const fs = require('fs');
 
 /**
  *
  * @param path {string}
  * @return {boolean}
  */
-export function isDirectory(path) {
+function isDirectory(path) {
     return fs.statSync(path).isDirectory();
 }
 
@@ -18,7 +18,7 @@ export function isDirectory(path) {
  * @param length {number}
  * @return {string}
  */
-export function generateRandomFilename(length) {
+function generateRandomFilename(length) {
     let filename = '';
     const validChar = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
@@ -34,7 +34,9 @@ export function generateRandomFilename(length) {
  * @param filePath {string}
  * @return {string}
  */
-export function normalizePath(filePath) {
+function normalizePath(filePath) {
     //replace all backslashes coming from cli running on windows machines by slashes
     return filePath.replace(/\\/g, '/');
 }
+
+module.exports = { isDirectory, generateRandomFilename, normalizePath };

--- a/cli/utils/file-utils.js
+++ b/cli/utils/file-utils.js
@@ -1,0 +1,40 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import * as fs from 'fs';
+
+/**
+ *
+ * @param path {string}
+ * @return {boolean}
+ */
+export function isDirectory(path) {
+    return fs.statSync(path).isDirectory();
+}
+
+/**
+ *
+ * @param length {number}
+ * @return {string}
+ */
+export function generateRandomFilename(length) {
+    let filename = '';
+    const validChar = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+    for (let i = 0; i < length; i++) {
+        filename += validChar.charAt(Math.floor(Math.random() * validChar.length));
+    }
+
+    return filename;
+}
+
+/**
+ *
+ * @param filePath {string}
+ * @return {string}
+ */
+export function normalizePath(filePath) {
+    //replace all backslashes coming from cli running on windows machines by slashes
+    return filePath.replace(/\\/g, '/');
+}

--- a/cli/utils/hash-utils.js
+++ b/cli/utils/hash-utils.js
@@ -1,0 +1,225 @@
+/**
+ * code based on appcenter-cli
+ */
+
+/**
+ * NOTE!!! This utility file is duplicated for use by the CodePush service (for server-driven hashing/
+ * integrity checks) and Management SDK (for end-to-end code signing), please keep them in sync.
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { isDirectory } from './file-utils';
+import { walk } from './promisfied-fs';
+
+// Do not throw an exception if either of these modules are missing, as they may not be needed by the
+// consumer of this file.
+const HASH_ALGORITHM = 'sha256';
+class PackageManifest {
+    /**
+     * @type {Map<string, string>}
+     * @private
+     */
+    _map;
+
+    /**
+     * @param map {Map<string, string>?}
+     * @public
+     */
+    constructor(map) {
+        if (map == null) {
+            map = new Map();
+        }
+        this._map = map;
+    }
+
+    /**
+     * @return {Map<string, string>}
+     * @public
+     */
+    toMap() {
+        return this._map;
+    }
+
+    /**
+     * @return {string}
+     * @public
+     */
+    computePackageHash() {
+        /**
+         * @type {string[]}
+         */
+        let entries = [];
+        this._map.forEach((hash, name) => {
+            entries.push(name + ':' + hash);
+        });
+
+        // Make sure this list is alphabetically ordered so that other clients
+        // can also compute this hash easily given the update contents.
+        entries = entries.sort();
+
+        return crypto.createHash(HASH_ALGORITHM).update(JSON.stringify(entries)).digest('hex');
+    }
+
+    /**
+     * @return {string}
+     * @public
+     */
+    serialize() {
+        const obj = {};
+
+        this._map.forEach(function (value, key) {
+            obj[key] = value;
+        });
+
+        return JSON.stringify(obj);
+    }
+
+    /**
+     * @param filePath {string}
+     * @return {string}
+     * @public
+     */
+    static normalizePath(filePath) {
+        //replace all backslashes coming from cli running on windows machines by slashes
+        return filePath.replace(/\\/g, '/');
+    }
+
+    /**
+     * @param relativeFilePath {string}
+     * @return {boolean}
+     * @public
+     */
+    static isIgnored(relativeFilePath) {
+        const __MACOSX = '__MACOSX/';
+        const DS_STORE = '.DS_Store';
+        const CODEPUSH_METADATA = '.codepushrelease';
+        return (
+            relativeFilePath.startsWith(__MACOSX) ||
+            relativeFilePath === DS_STORE ||
+            relativeFilePath.endsWith('/' + DS_STORE) ||
+            relativeFilePath === CODEPUSH_METADATA ||
+            relativeFilePath.endsWith('/' + CODEPUSH_METADATA)
+        );
+    }
+}
+
+/**
+ *
+ * @param directoryPath {string}
+ * @param basePath {string}
+ * @return {Promise<string>}
+ */
+export async function generatePackageHashFromDirectory(directoryPath, basePath) {
+    try {
+        if (!isDirectory(directoryPath)) {
+            throw new Error('Not a directory. Please either create a directory, or use hashFile().');
+        }
+    } catch (error) {
+        throw new Error('Directory does not exist. Please either create a directory, or use hashFile().');
+    }
+
+    /**
+     * @type {PackageManifest}
+     */
+    const manifest = await generatePackageManifestFromDirectory(directoryPath, basePath);
+    return manifest.computePackageHash();
+}
+
+/**
+ *
+ * @param directoryPath {string}
+ * @param basePath {string}
+ * @return {Promise<PackageManifest>}
+ */
+function generatePackageManifestFromDirectory(directoryPath, basePath) {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+        /**
+         * @type {Map<string, string>}
+         */
+        const fileHashesMap = new Map();
+
+        /**
+         * @type {string[]}
+         */
+        const files = await walk(directoryPath);
+
+        if (!files || files.length === 0) {
+            reject('Error: Cannot sign the release because no files were found.');
+            return;
+        }
+
+        /**
+         * @type {Promise<void>}
+         */
+        // Hash the files sequentially, because streaming them in parallel is not necessarily faster
+        const generateManifestPromise = files.reduce((soFar, filePath) => {
+            return soFar.then(() => {
+                /**
+                 * @type {string}
+                 */
+                const relativePath = PackageManifest.normalizePath(path.relative(basePath, filePath));
+                if (!PackageManifest.isIgnored(relativePath)) {
+                    return hashFile(filePath).then((hash) => {
+                        fileHashesMap.set(relativePath, hash);
+                    });
+                }
+            });
+        }, Promise.resolve(null));
+
+        generateManifestPromise.then(() => {
+            resolve(new PackageManifest(fileHashesMap));
+        }, reject);
+    });
+}
+
+/**
+ *
+ * @param filePath {string}
+ * @return {Promise<string>}
+ */
+function hashFile(filePath) {
+    /**
+     * @type {fs.ReadStream}
+     */
+    const readStream = fs.createReadStream(filePath);
+    return hashStream(readStream);
+}
+
+/**
+ *
+ * @param readStream {stream.Readable}
+ * @return {Promise<string>}
+ */
+function hashStream(readStream) {
+    return new Promise((resolve, reject) => {
+        /**
+         * @type {stream.Transform}
+         */
+        const _hashStream = crypto.createHash(HASH_ALGORITHM)
+
+        readStream
+            .on('error', (error) => {
+                _hashStream.end();
+                reject(error);
+            })
+            .on('end', () => {
+                _hashStream.end();
+
+                /**
+                 * @type {Buffer}
+                 */
+                const buffer = _hashStream.read();
+                /**
+                 * @type {string}
+                 */
+                const hash = buffer.toString('hex');
+
+                resolve(hash);
+            });
+
+        readStream.pipe(_hashStream);
+    });
+}

--- a/cli/utils/hash-utils.js
+++ b/cli/utils/hash-utils.js
@@ -7,11 +7,11 @@
  * integrity checks) and Management SDK (for end-to-end code signing), please keep them in sync.
  */
 
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
-import { isDirectory } from './file-utils';
-import { walk } from './promisfied-fs';
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { isDirectory } = require('./file-utils');
+const { walk } = require('./promisfied-fs');
 
 // Do not throw an exception if either of these modules are missing, as they may not be needed by the
 // consumer of this file.
@@ -111,7 +111,7 @@ class PackageManifest {
  * @param basePath {string}
  * @return {Promise<string>}
  */
-export async function generatePackageHashFromDirectory(directoryPath, basePath) {
+async function generatePackageHashFromDirectory(directoryPath, basePath) {
     try {
         if (!isDirectory(directoryPath)) {
             throw new Error('Not a directory. Please either create a directory, or use hashFile().');
@@ -223,3 +223,5 @@ function hashStream(readStream) {
         readStream.pipe(_hashStream);
     });
 }
+
+module.exports = { generatePackageHashFromDirectory };

--- a/cli/utils/promisfied-fs.js
+++ b/cli/utils/promisfied-fs.js
@@ -1,0 +1,27 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ *
+ * @param dir {string}
+ * @return {Promise<string[]>}
+ */
+export async function walk(dir) {
+    const stats = await fs.stat(dir);
+    if (stats.isDirectory()) {
+        /**
+         * @type {string[]}
+         */
+        let files = [];
+        for (const file of await fs.readdir(dir)) {
+            files = files.concat(await walk(path.join(dir, file)));
+        }
+        return files;
+    } else {
+        return [dir];
+    }
+}

--- a/cli/utils/promisfied-fs.js
+++ b/cli/utils/promisfied-fs.js
@@ -2,15 +2,15 @@
  * code based on appcenter-cli
  */
 
-import { promises as fs } from 'fs';
-import path from 'path';
+const { promises: fs } = require('fs');
+const path = require('path');
 
 /**
  *
  * @param dir {string}
  * @return {Promise<string[]>}
  */
-export async function walk(dir) {
+async function walk(dir) {
     const stats = await fs.stat(dir);
     if (stats.isDirectory()) {
         /**
@@ -25,3 +25,5 @@ export async function walk(dir) {
         return [dir];
     }
 }
+
+module.exports = { walk };

--- a/cli/utils/zip.js
+++ b/cli/utils/zip.js
@@ -2,11 +2,11 @@
  * code based on appcenter-cli
  */
 
-import fs from 'fs';
-import path from 'path';
-import yazl from 'yazl';
-import { generateRandomFilename, normalizePath, isDirectory } from './file-utils';
-import { walk } from './promisfied-fs';
+const fs = require('fs');
+const path = require('path');
+const yazl = require('yazl');
+const { generateRandomFilename, normalizePath, isDirectory } = require('./file-utils');
+const { walk } = require('./promisfied-fs');
 
 /**
  * @typedef {{ sourceLocation: string, targetLocation: string }} ReleaseFile
@@ -16,7 +16,7 @@ import { walk } from './promisfied-fs';
  * @param updateContentsPath {string}
  * @return {Promise<string>}
  */
-export default function zip(updateContentsPath) {
+function zip(updateContentsPath) {
 
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
@@ -85,3 +85,5 @@ export default function zip(updateContentsPath) {
         zipFile.end();
     });
 }
+
+module.exports = zip;

--- a/cli/utils/zip.js
+++ b/cli/utils/zip.js
@@ -1,0 +1,87 @@
+/**
+ * code based on appcenter-cli
+ */
+
+import fs from 'fs';
+import path from 'path';
+import yazl from 'yazl';
+import { generateRandomFilename, normalizePath, isDirectory } from './file-utils';
+import { walk } from './promisfied-fs';
+
+/**
+ * @typedef {{ sourceLocation: string, targetLocation: string }} ReleaseFile
+ */
+
+/**
+ * @param updateContentsPath {string}
+ * @return {Promise<string>}
+ */
+export default function zip(updateContentsPath) {
+
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+        /**
+         * @type {ReleaseFile[]}
+         */
+        const releaseFiles = [];
+
+        try {
+            if (!isDirectory(updateContentsPath)) {
+                releaseFiles.push({
+                    sourceLocation: updateContentsPath,
+                    targetLocation: normalizePath(path.basename(updateContentsPath)), // Put the file in the root
+                });
+            }
+        } catch (error) {
+            error.message = error.message + ' Make sure you have added the platform you are making a release to.`.';
+            reject(error);
+        }
+
+        /**
+         * @type {string}
+         */
+        const directoryPath = updateContentsPath;
+        const baseDirectoryPath = path.join(directoryPath, '..'); // For legacy reasons, put the root directory in the zip
+
+        /**
+         * @type {string[]}
+         */
+        const files = await walk(updateContentsPath);
+
+        files.forEach((filePath) => {
+            /**
+             * @type {string}
+             */
+            const relativePath = path.relative(baseDirectoryPath, filePath);
+            releaseFiles.push({
+                sourceLocation: filePath,
+                targetLocation: normalizePath(relativePath),
+            });
+        });
+
+        /**
+         * @type {string}
+         */
+        const packagePath = path.join(process.cwd(), generateRandomFilename(15) + '.zip');
+        const zipFile = new yazl.ZipFile();
+        /**
+         * @type {fs.WriteStream}
+         */
+        const writeStream = fs.createWriteStream(packagePath);
+
+        zipFile.outputStream
+            .pipe(writeStream)
+            .on('error', (error) => {
+                reject(error);
+            })
+            .on('close', () => {
+                resolve(packagePath);
+            });
+
+        releaseFiles.forEach((releaseFile) => {
+            zipFile.addFile(releaseFile.sourceLocation, releaseFile.targetLocation);
+        });
+
+        zipFile.end();
+    });
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Soomgo Mobile Team (originally Microsoft Corporation)",
   "license": "MIT",
   "bin": {
-    "code-push": "./cli/index.js"
+    "code-push": "cli/index.js"
   },
   "scripts": {
     "clean": "shx rm -rf bin",
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Soomgo-Mobile/react-native-code-push"
+    "url": "git+https://github.com/Soomgo-Mobile/react-native-code-push.git"
   },
   "dependencies": {
     "code-push": "^4.2.2",

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -13,7 +13,7 @@ export interface UpdateCheckRequest {
     package_hash?: string;
 }
 
-type SortingMethod = (a: ReleaseVersion, b: ReleaseVersion) => number
+type SortingMethod = (a: ReleaseVersion, b: ReleaseVersion) => number;
 
 export abstract class BaseVersioning {
     constructor(releaseHistory: ReleaseHistoryInterface, sortingMethod?: SortingMethod)
@@ -75,7 +75,7 @@ interface CodePushSharedOptions {
      */
     runtimeVersion: string;
     /**
-     * Specifies versioning policy.    
+     * Specifies versioning policy.
      * Defaults to `SemverVersioning`
      */
     versioning?: typeof BaseVersioning;
@@ -344,7 +344,7 @@ declare function CodePush(options?: CodePushOptions): (x: any) => any;
  *
  * @param x the React Component that will decorated
  */
-declare function CodePush(x: any): any
+declare function CodePush(x: any): any;
 
 declare namespace CodePush {
     /**
@@ -367,7 +367,7 @@ declare namespace CodePush {
      *
      * @param updateState The state of the update you want to retrieve the metadata for. Defaults to UpdateState.RUNNING.
      */
-    function getUpdateMetadata(updateState?: UpdateState) : Promise<LocalPackage|null>;
+    function getUpdateMetadata(updateState?: UpdateState): Promise<LocalPackage|null>;
 
     /**
      * Notifies the CodePush runtime that an installed update is considered successful.
@@ -413,7 +413,7 @@ declare namespace CodePush {
         BASE: typeof BaseVersioning,
         SEMVER: typeof BaseVersioning,
         INCREMENTAL: typeof BaseVersioning,
-    }
+    };
 
     /**
      * Indicates when you would like an installed update to actually be applied.


### PR DESCRIPTION
closes #18 


The new code additions are substantial but largely derived from the `appcenter-cli` source code.
Moreover, as this code is already in use within the Soomgo app deployment scripts, its stability is not a concern.

Considering this, the parts of the code that require review are as follows:
- cli/commands/bundleCodePush.js
- cli/index.js

### Test Plan

1. Use verdaccio to publish the npm package to a local repository.
2. Install the package in the Soomgo ReactNative project.
3. In the project directory, run the command `npx code-push bundle` to confirm that the CodePush bundle is generated correctly.


![image](https://github.com/user-attachments/assets/e78ac20f-9bd9-4ea6-ba6d-ce45c79bb96e)

The contents of the generated CodePush bundle were checked after unzipping, and it was confirmed that the bundle file is Hermes-compiled.
![image](https://github.com/user-attachments/assets/b120a69e-89b7-4379-8d12-5153cc90b052)
