### PR TITLE
fix: add missing dependency and update lock files

### DIFF
--- a/babel-plugin-code-push/package-lock.json
+++ b/babel-plugin-code-push/package-lock.json
@@ -28,13 +28,17 @@
       "version": "8.3.1",
       "license": "MIT",
       "dependencies": {
-        "code-push": "^4.2.2",
+        "commander": "^12.1.0",
         "glob": "^7.1.7",
         "hoist-non-react-statics": "^3.3.2",
-        "inquirer": "^8.1.5",
+        "inquirer": "^8.2.6",
         "plist": "^3.0.4",
         "semver": "^7.3.5",
+        "shelljs": "^0.8.5",
         "xcode": "3.0.1"
+      },
+      "bin": {
+        "code-push": "cli/index.js"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -46,6 +50,7 @@
         "@types/node": "^14.0.27",
         "@types/q": "^1.5.4",
         "@types/semver": "^7.5.8",
+        "@types/shelljs": "^0.8.15",
         "archiver": "latest",
         "babel-jest": "^29.7.0",
         "body-parser": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "slash": "^3.0.0",
         "tslint": "^6.1.3",
         "typescript": "^4.4.3",
-        "typescript-eslint": "^8.11.0"
+        "typescript-eslint": "^8.11.0",
+        "yazl": "^3.3.1"
       }
     },
     "code-push-plugin-testing-framework": {
@@ -11069,6 +11070,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
+    },
+    "node_modules/yazl/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -19182,6 +19203,23 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
           "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^1.0.0"
+      },
+      "dependencies": {
+        "buffer-crc32": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+          "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "slash": "^3.0.0",
     "tslint": "^6.1.3",
     "typescript": "^4.4.3",
-    "typescript-eslint": "^8.11.0"
+    "typescript-eslint": "^8.11.0",
+    "yazl": "^3.3.1"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
The original `appcenter-cli` uses `yazl` version 2.5.1, but the latest version is 3.3.1.
The breaking change between 2.5.1 and 3.3.1 is the dropped support for older Node.js versions, so it should be safe to update.