### PR TITLE
feat: implement release history creation functionality

### DIFF
--- a/babel-plugin-code-push/index.js
+++ b/babel-plugin-code-push/index.js
@@ -13,9 +13,9 @@ module.exports = function (babel, options) {
   const configPath =
     options.configPath != null
       ? path.resolve(options.configPath)
-      : path.resolve(process.cwd(), "codepush.config.js");
+      : path.resolve(process.cwd(), "code-push.config.js");
 
-  // Load config and imports from `codepush.config.js`
+  // Load config and imports from `code-push.config.js`
   const { config, configImports, importedIdentifiers } = loadConfig(
     babel,
     configPath
@@ -32,10 +32,10 @@ module.exports = function (babel, options) {
           },
         });
 
-        // Add missing imports from codepush.config.js to the input file
+        // Add missing imports from code-push.config.js to the input file
         configImports.forEach((importNode) => {
           if (!existingImports.has(importNode.source.value)) {
-            // Clone the import node from codepush.config.js and add it to the input file
+            // Clone the import node from code-push.config.js and add it to the input file
             path.node.body.unshift(t.cloneNode(importNode));
           }
         });
@@ -82,7 +82,7 @@ module.exports = function (babel, options) {
 function loadConfig(babel, configPath) {
   if (!fs.existsSync(configPath)) {
     throw new Error(
-      "codepush.config.js not found. Please ensure it exists in the root directory."
+      "code-push.config.js not found. Please ensure it exists in the root directory."
     );
   }
 

--- a/cli/commands/createHistoryCommand/createReleaseHistory.js
+++ b/cli/commands/createHistoryCommand/createReleaseHistory.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ *
+ * @param targetVersion {string}
+ * @param setReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     jsonFilePath: string,
+ *     releaseInfo: ReleaseHistoryInterface,
+ *     platform: string,
+ *     identifier: string
+ *   ): Promise<void>}
+ * @param platform {"ios" | "android"}
+ * @param identifier {string}
+ * @returns {Promise<void>}
+ */
+async function createReleaseHistory(
+    targetVersion,
+    setReleaseHistory,
+    platform,
+    identifier,
+) {
+    const BINARY_RELEASE = {
+        enabled: true,
+        mandatory: false,
+        downloadUrl: "",
+        packageHash: "",
+    };
+
+    /** @type {ReleaseHistoryInterface} */
+    const INITIAL_HISTORY = {
+        [targetVersion]: BINARY_RELEASE
+    };
+
+    try {
+        const JSON_FILE_NAME = `${targetVersion}.json`;
+        const JSON_FILE_PATH = path.resolve(process.cwd(), JSON_FILE_NAME);
+
+        console.log(`log: creating JSON file... ("${JSON_FILE_NAME}")\n`, JSON.stringify(INITIAL_HISTORY, null, 2));
+        fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(INITIAL_HISTORY));
+
+        await setReleaseHistory(targetVersion, JSON_FILE_PATH, INITIAL_HISTORY, platform, identifier)
+
+        fs.unlinkSync(JSON_FILE_PATH);
+    } catch (error) {
+        console.error('Error occurred while creating new history:', error);
+        process.exit(1)
+    }
+}
+
+module.exports = { createReleaseHistory: createReleaseHistory }

--- a/cli/commands/createHistoryCommand/index.js
+++ b/cli/commands/createHistoryCommand/index.js
@@ -1,0 +1,28 @@
+const { program, Option } = require("commander");
+const { findAndReadConfigFile } = require("../../utils/fsUtils");
+const { createReleaseHistory } = require("./createReleaseHistory");
+
+program.command('create-history')
+    .description('Create a new release history for the binary app.')
+    .requiredOption('-v, --target-version <string>', 'target app binary version')
+    .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
+    .option('-i, --identifier <string>', 'additional characters to identify the release')
+    .option('-c, --config <path>', 'set config file name (JS/TS)', 'codepush.config.ts')
+    /**
+     * @param {Object} options
+     * @param {string} options.targetVersion
+     * @param {string} options.platform
+     * @param {string} options.identifier
+     * @param {string} options.config
+     * @return {void}
+     */
+    .action(async (options) => {
+        const config = findAndReadConfigFile(process.cwd(), options.config);
+
+        await createReleaseHistory(
+            options.targetVersion,
+            config.setReleaseHistory,
+            options.platform,
+            options.identifier
+        );
+    });

--- a/cli/commands/createHistoryCommand/index.js
+++ b/cli/commands/createHistoryCommand/index.js
@@ -7,7 +7,7 @@ program.command('create-history')
     .requiredOption('-v, --target-version <string>', 'target app binary version')
     .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
     .option('-i, --identifier <string>', 'additional characters to identify the release')
-    .option('-c, --config <path>', 'set config file name (JS/TS)', 'codepush.config.ts')
+    .option('-c, --config <path>', 'set config file name (JS/TS)', 'code-push.config.ts')
     /**
      * @param {Object} options
      * @param {string} options.targetVersion

--- a/cli/commands/uploadCommand/index.js
+++ b/cli/commands/uploadCommand/index.js
@@ -6,7 +6,7 @@ const { upload } = require("./upload");
 program.command('upload')
     .requiredOption('-s, --source-file-path <string>', 'path to the file to upload')
     .requiredOption('-t, --target <string>', 'upload target')
-    .option('-c, --config <path>', 'set config file name (JS/TS)', 'codepush.config.ts')
+    .option('-c, --config <path>', 'set config file name (JS/TS)', 'code-push.config.ts')
     .option('-p, --preserve-file', 'do not delete uploaded file after upload')
     /**
      * @param {Object} options

--- a/cli/constant.js
+++ b/cli/constant.js
@@ -1,3 +1,3 @@
 module.exports = {
-  configFileName: "codepush.config.ts",
+  configFileName: "code-push.config.ts",
 };

--- a/cli/index.js
+++ b/cli/index.js
@@ -22,6 +22,11 @@ program
  */
 require("./commands/bundleCommand");
 
+/**
+ * npx code-push create-history
+ */
+require('./commands/createHistoryCommand');
+
 require('./commands/uploadCommand');
 
 program.parse();


### PR DESCRIPTION
closes: #20 

#### `create-history` command

This command must be executed when deploying a binary app to the store.
For example, if the 1.0.0 app is released to the store, release history corresponding to the 1.0.0 version app should begin recording.
Updates will have separate deployment histories based on the platform (iOS/Android) and environment (e.g., Production/Staging).

Library users are required to implement the `setReleaseHistory` function in the `code-push.config.ts` configuration file.
- If managing deployment history by creating JSON files and uploading them to S3:
The implementation must specify JSON files according to the target app version and runtime environment by utilizing upload paths and file names.
- Alternatively, it's possible to implement a method for management using a REST API. (or Firebase DB, etc..)

We plan to provide an example implementation of the configuration file in future documentation.