### PR TITLE
feat: implement release history modification functionality

### DIFF
--- a/cli/commands/updateHistoryCommand/index.js
+++ b/cli/commands/updateHistoryCommand/index.js
@@ -1,0 +1,48 @@
+const { program, Option } = require("commander");
+const { findAndReadConfigFile } = require("../../utils/fsUtils");
+const { updateReleaseHistory } = require("./updateReleaseHistory");
+
+program.command('update-history')
+    .requiredOption('-v, --app-version <string>', 'The app version for which update information is to be modified.')
+    .requiredOption('-b, --binary-version <string>', 'The target binary version of the app for which update information is to be modified.')
+    .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
+    .option('-i, --identifier <string>', 'additional characters to identify the release')
+    .option('-c, --config <path>', 'set config file name (JS/TS)', 'code-push.config.ts')
+    .option('-m, --mandatory <bool>', 'make the release to be mandatory', parseBoolean, undefined)
+    .option('-e, --enable <bool>', 'make the release to be enabled', parseBoolean, undefined)
+    /**
+     * @param {Object} options
+     * @param {string} options.appVersion
+     * @param {string} options.binaryVersion
+     * @param {string} options.platform
+     * @param {string} options.identifier
+     * @param {string} options.config
+     * @param {string} options.mandatory
+     * @param {string} options.enable
+     * @return {void}
+     */
+    .action(async (options) => {
+        const config = findAndReadConfigFile(process.cwd(), options.config);
+
+        if (typeof options.mandatory !== "boolean" && typeof options.enable !== "boolean") {
+            console.error('No options specified. Exiting the program.')
+            process.exit(1)
+        }
+
+        await updateReleaseHistory(
+            options.appVersion,
+            options.binaryVersion,
+            config.getReleaseHistory,
+            config.setReleaseHistory,
+            options.platform,
+            options.identifier,
+            options.mandatory,
+            options.enable,
+        )
+    });
+
+function parseBoolean(value) {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    else return undefined;
+}

--- a/cli/commands/updateHistoryCommand/updateReleaseHistory.js
+++ b/cli/commands/updateHistoryCommand/updateReleaseHistory.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ *
+ * @param appVersion {string}
+ * @param binaryVersion {string}
+ * @param getReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     platform: string,
+ *     identifier?: string
+ *   ): Promise<ReleaseHistoryInterface>}
+ * @param setReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     jsonFilePath: string,
+ *     releaseInfo: ReleaseHistoryInterface,
+ *     platform: string,
+ *     identifier?: string
+ *   ): Promise<void>}
+ * @param platform {"ios" | "android"}
+ * @param identifier {string?}
+ * @param mandatory {boolean?}
+ * @param enable {boolean?}
+ * @returns {Promise<void>}
+ */
+async function updateReleaseHistory(
+    appVersion,
+    binaryVersion,
+    getReleaseHistory,
+    setReleaseHistory,
+    platform,
+    identifier,
+    mandatory,
+    enable,
+) {
+    const releaseHistory = await getReleaseHistory(binaryVersion, platform, identifier);
+
+    const updateInfo = releaseHistory[appVersion]
+    if (!updateInfo) throw new Error(`v${appVersion} is not released`)
+
+    if (typeof mandatory === "boolean") updateInfo.mandatory = mandatory;
+    if (typeof enable === "boolean") updateInfo.enabled = enable;
+
+    try {
+        const JSON_FILE_NAME = `${binaryVersion}.json`;
+        const JSON_FILE_PATH = path.resolve(process.cwd(), JSON_FILE_NAME);
+
+        console.log(`log: creating JSON file... ("${JSON_FILE_NAME}")\n`, JSON.stringify(releaseHistory, null, 2));
+        fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(releaseHistory));
+
+        await setReleaseHistory(binaryVersion, JSON_FILE_PATH, releaseHistory, platform, identifier)
+
+        fs.unlinkSync(JSON_FILE_PATH);
+    } catch (error) {
+        console.error('Error occurred while updating history:', error);
+        process.exit(1)
+    }
+}
+
+module.exports = { updateReleaseHistory: updateReleaseHistory }

--- a/cli/index.js
+++ b/cli/index.js
@@ -27,6 +27,11 @@ require("./commands/bundleCommand");
  */
 require('./commands/createHistoryCommand');
 
+/**
+ * npx code-push update-history
+ */
+require('./commands/updateHistoryCommand');
+
 require('./commands/uploadCommand');
 
 program.parse();


### PR DESCRIPTION
closes: #21 

#### `update-history` command

This command is used to modify update information released via CodePush.  
It allows changing the `enable` and `mandatory` settings of updates.  

Library users are required to implement the `setReleaseHistory` and `getReleaseHistory` functions in the `code-push.config.ts` configuration file.  

An example implementation will be included in future documentation.  