### PR TITLE
feat: implement release command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ Examples/testapp_rn
 
 # Android debug build files (conflict ignoring #Visual Studio files)
 !android/app/src/debug/
+
+# prevent CLI code ignored (ignored by "[Rr]elease*/")
+!cli/commands/releaseCommand/

--- a/cli/commands/releaseCommand/addToReleaseHistory.js
+++ b/cli/commands/releaseCommand/addToReleaseHistory.js
@@ -1,0 +1,75 @@
+const path = require("path");
+const fs = require("fs");
+
+/**
+ *
+ * @param appVersion {string}
+ * @param binaryVersion {string}
+ * @param bundleDownloadUrl {string}
+ * @param packageHash {string}
+ * @param getReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     platform: string,
+ *     identifier?: string
+ *   ): Promise<ReleaseHistoryInterface>}
+ * @param setReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     jsonFilePath: string,
+ *     releaseInfo: ReleaseHistoryInterface,
+ *     platform: string,
+ *     identifier?: string
+ *   ): Promise<void>}
+ * @param platform {"ios" | "android"}
+ * @param identifier {string?}
+ * @param mandatory {boolean?}
+ * @param enable {boolean?}
+ * @returns {Promise<void>}
+ */
+async function addToReleaseHistory(
+    appVersion,
+    binaryVersion,
+    bundleDownloadUrl,
+    packageHash,
+    getReleaseHistory,
+    setReleaseHistory,
+    platform,
+    identifier,
+    mandatory,
+    enable,
+) {
+    const releaseHistory = await getReleaseHistory(binaryVersion, platform, identifier);
+
+    const updateInfo = releaseHistory[appVersion]
+    if (updateInfo) {
+        console.error(`v${appVersion} is already released`)
+        process.exit(1)
+    }
+
+    const newReleaseHistory = structuredClone(releaseHistory);
+
+    newReleaseHistory[appVersion] = {
+        enabled: enable,
+        mandatory: mandatory,
+        downloadUrl: bundleDownloadUrl,
+        packageHash: packageHash,
+    }
+
+    try {
+        const JSON_FILE_NAME = `${binaryVersion}.json`;
+        const JSON_FILE_PATH = path.resolve(process.cwd(), JSON_FILE_NAME);
+
+        console.log(`log: creating JSON file... ("${JSON_FILE_NAME}")\n`, JSON.stringify(newReleaseHistory, null, 2));
+        fs.writeFileSync(JSON_FILE_PATH, JSON.stringify(newReleaseHistory));
+
+        await setReleaseHistory(binaryVersion, JSON_FILE_PATH, newReleaseHistory, platform, identifier)
+
+        fs.unlinkSync(JSON_FILE_PATH);
+    } catch (error) {
+        console.error('Error occurred while updating history:', error);
+        process.exit(1)
+    }
+}
+
+module.exports = { addToReleaseHistory: addToReleaseHistory }

--- a/cli/commands/releaseCommand/index.js
+++ b/cli/commands/releaseCommand/index.js
@@ -1,0 +1,57 @@
+const { program, Option } = require("commander");
+const { findAndReadConfigFile } = require("../../utils/fsUtils");
+const { release } = require("./release");
+
+program.command('release')
+    .requiredOption('-b, --binary-version <string>', 'target app binary version')
+    .requiredOption('-v, --app-version <string>', 'The app version to be released')
+    .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
+    .option('-i, --identifier <string>', 'additional characters to identify the release')
+    .option('-c, --config <path>', 'set config file name (JS/TS)', 'code-push.config.ts')
+    .option('-o, --output-path <string>', 'path to output root directory', 'build')
+    .option('-e, --entry-file <string>', 'path to JS/TS entry file', 'index.ts')
+    .option('-j, --js-bundle-name <string>', 'JS bundle file name (default-ios: "main.jsbundle" / default-android: "index.android.bundle")')
+    .requiredOption('-d, --destination-path <string>', 'CodePush bundle upload destination path')
+    .option('-m, --mandatory <bool>', 'make the release to be mandatory', parseBoolean, false)
+    .option('--enable <bool>', 'make the release to be enabled', parseBoolean, true)
+    /**
+     * @param {Object} options
+     * @param {string} options.binaryVersion
+     * @param {string} options.appVersion
+     * @param {string} options.platform
+     * @param {string} options.identifier
+     * @param {string} options.config
+     * @param {string} options.outputPath
+     * @param {string} options.entryFile
+     * @param {string} options.bundleName
+     * @param {string} options.destinationPath
+     * @param {string} options.mandatory
+     * @param {string} options.enable
+     * @return {void}
+     */
+    .action(async (options) => {
+        const config = findAndReadConfigFile(process.cwd(), options.config);
+
+        await release(
+            config.bundleUploader,
+            config.getReleaseHistory,
+            config.setReleaseHistory,
+            options.binaryVersion,
+            options.appVersion,
+            options.platform,
+            options.identifier,
+            options.outputPath,
+            options.entryFile,
+            options.bundleName,
+            options.mandatory,
+            options.enable,
+        )
+
+        console.log('🚀 Release completed.')
+    });
+
+function parseBoolean(value) {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    else return undefined;
+}

--- a/cli/commands/releaseCommand/release.js
+++ b/cli/commands/releaseCommand/release.js
@@ -1,0 +1,88 @@
+const { bundleCodePush } = require("../bundleCommand/bundleCodePush");
+const { addToReleaseHistory } = require("./addToReleaseHistory");
+
+/**
+ * @param bundleUploader {
+ *   function(
+ *       source: string,
+ *       platform: "ios" | "android",
+ *       identifier?: string
+ *   ): Promise<{ downloadUrl: string }>}
+ * @param getReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     platform: "ios" | "android",
+ *     identifier?: string
+ *   ): Promise<ReleaseHistoryInterface>}
+ * @param setReleaseHistory {
+ *   function(
+ *     targetBinaryVersion: string,
+ *     jsonFilePath: string,
+ *     releaseInfo: ReleaseHistoryInterface,
+ *     platform: "ios" | "android",
+ *     identifier?: string
+ *   ): Promise<void>}
+ * @param binaryVersion {string}
+ * @param appVersion {string}
+ * @param platform {"ios" | "android"}
+ * @param identifier {string?}
+ * @param outputPath {string}
+ * @param entryFile {string}
+ * @param jsBundleName {string}
+ * @param mandatory {boolean}
+ * @param enable {boolean}
+ * @return {Promise<void>}
+ */
+async function release(
+    bundleUploader,
+    getReleaseHistory,
+    setReleaseHistory,
+    binaryVersion,
+    appVersion,
+    platform,
+    identifier,
+    outputPath,
+    entryFile,
+    jsBundleName,
+    mandatory,
+    enable,
+) {
+    const { bundleFileName, packageHash } = await bundleCodePush(
+        platform,
+        outputPath,
+        entryFile,
+        jsBundleName,
+    );
+
+    const downloadUrl = await (async () => {
+        try {
+            const { downloadUrl } = await bundleUploader(`./${bundleFileName}`, platform, identifier);
+            return downloadUrl
+        } catch (error) {
+            console.error('Failed to upload the bundle file. Exiting the program.', error)
+            process.exit(1)
+        }
+    })();
+
+    await addToReleaseHistory(
+        appVersion,
+        binaryVersion,
+        downloadUrl,
+        packageHash,
+        getReleaseHistory,
+        setReleaseHistory,
+        platform,
+        identifier,
+        mandatory,
+        enable,
+    )
+
+    deleteUploadedBundleFile(bundleFileName);
+}
+
+function deleteUploadedBundleFile(bundleFileName) {
+    const fs = require('fs');
+    fs.unlinkSync(`./${bundleFileName}`);
+}
+
+module.exports = { release: release }

--- a/cli/index.js
+++ b/cli/index.js
@@ -32,6 +32,11 @@ require('./commands/createHistoryCommand');
  */
 require('./commands/updateHistoryCommand');
 
+/**
+ * npx code-push release
+ */
+require('./commands/releaseCommand');
+
 require('./commands/uploadCommand');
 
 program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,9 @@
         "typescript": "^4.4.3",
         "typescript-eslint": "^8.11.0",
         "yazl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "code-push-plugin-testing-framework": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     "typescript-eslint": "^8.11.0",
     "yazl": "^3.3.1"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "rnpm": {
     "android": {
       "packageInstance": "new CodePush(getResources().getString(R.string.CodePushDeploymentKey), getApplicationContext(), BuildConfig.DEBUG)"


### PR DESCRIPTION
closes: #23

#### `release` command

Library users are required to implement the `bundleUploader`, `setReleaseHistory` and `getReleaseHistory` functions in the `code-push.config.ts` configuration file.  

An example implementation will be included in future documentation.  