### PR TITLE
fix: modify nodeModulesPath to detect correct path for android build

### DIFF
--- a/android/codepush.gradle
+++ b/android/codepush.gradle
@@ -69,9 +69,9 @@ gradle.projectsEvaluated {
 
         def nodeModulesPath;
         if (project.hasProperty('nodeModulesPath')) {
-            nodeModulesPath = "${project.nodeModulesPath}/react-native-code-push"
+            nodeModulesPath = "${project.nodeModulesPath}/@bravemobile/react-native-code-push"
         } else {
-            nodeModulesPath = findNodeModulePath(projectDir, "react-native-code-push")
+            nodeModulesPath = findNodeModulePath(projectDir, "@bravemobile/react-native-code-push")
         }
 
         def targetName = variant.name.capitalize()


### PR DESCRIPTION
안드로이드 빌드 시 node_modules에서 @bravemobile/react-native-code-push가 아닌 react-native-code-push를 찾으려고 해, 올바른 경로를 찾지 못하는 문제가 발생하는 것 같습니다.