### PR TITLE
fix: updated rules for ProGuard-enabled projects

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -20,6 +20,22 @@
 -keepclassmembers class com.facebook.react.ReactInstanceManager {
     private final ** mBundleLoader;
 }
+-keepclassmembers class com.facebook.react.ReactDelegate {
+    private ** mReactHost; # bridgeless
+    public void reload(...); # RN 0.74 and above
+}
+# RN 0.74 and above
+-keepclassmembers class com.facebook.react.ReactActivity {
+    public ** getReactDelegate(...);
+}
+# bridgeless
+-keepclassmembers class com.facebook.react.defaults.DefaultReactHostDelegate {
+    private ** jsBundleLoader;
+}
+# bridgeless
+-keepclassmembers class com.facebook.react.runtime.ReactHostImpl {
+    private final ** mReactHostDelegate;
+}
 
 # Can't find referenced class org.bouncycastle.**
 -dontwarn com.nimbusds.jose.**


### PR DESCRIPTION
closes: #67 

### Test

The update and clear behaviors worked correctly when `restartApp` was called.

- Android RN 0.74 ~ 0.78
- New Architecture enabled/disabled & ProGuard enabled
