### PR TITLE
feat(cli): add expo framework support to bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Create a new release history for a specific binary app version.
 **Example:**
 - Create a new release history for the binary app version `1.0.0`. 
 
-```
+```bash
 npx code-push create-history --binary-version 1.0.0 --platform ios --identifier staging
 ```
 
@@ -342,7 +342,7 @@ Display the release history for a specific binary app version.
 **Example:**
 - Show the release history for the binary app version `1.0.0`.
 
-```
+```bash
 npx code-push show-history --binary-version 1.0.0 --platform ios --identifier staging
 ```
 
@@ -354,11 +354,15 @@ Release a CodePush update for a specific binary app version.
 **Example:**
 - Release a CodePush update `1.0.1` targeting the binary app version `1.0.0`.
 
-```
+```bash
 npx code-push release --binary-version 1.0.0 --app-version 1.0.1 \
                       --platform ios --identifier staging --entry-file index.js \
                       --mandatory true
+
+# Expo project
+npx code-push release --type expo --binary-version 1.0.0 --app-version 1.0.1 --platform ios
 ```
+- `--type`: Project type (react-native (default) | expo)
 - `--binary-version`: The version of the binary app that the CodePush update is targeting.
 - `--app-version`: The version of the CodePush update itself.
 
@@ -375,7 +379,7 @@ Update the release history for a specific CodePush update.
 **Example:**
 - Rollback the CodePush update `1.0.1` (targeting the binary app version `1.0.0`).
 
-```
+```bash
 npx code-push update-history --binary-version 1.0.0 --app-version 1.0.1 \
                              --platform ios --identifier staging \
                              --enable false
@@ -386,10 +390,16 @@ npx code-push update-history --binary-version 1.0.0 --app-version 1.0.1 \
 Create a CodePush bundle file.
 
 **Example:**
-```
+```bash
 npx code-push bundle --platform android --entry-file index.js
+
+# Expo project
+npx code-push bundle --type expo --platform android --entry-file index.js
 ```
+- `--type`: Project type (react-native (default) | expo)
 
 By default, the bundle file is created in the `/build/bundleOutput` directory.
+
+>[!NOTE] For Expo projects, the CLI uses `expo export:embed` command for bundling instead of React Native's bundle command.
 
 (The file name represents a hash value of the bundle content.)

--- a/README.md
+++ b/README.md
@@ -360,9 +360,9 @@ npx code-push release --binary-version 1.0.0 --app-version 1.0.1 \
                       --mandatory true
 
 # Expo project
-npx code-push release --type expo --binary-version 1.0.0 --app-version 1.0.1 --platform ios
+npx code-push release --framework expo --binary-version 1.0.0 --app-version 1.0.1 --platform ios
 ```
-- `--type`: Project type (react-native (default) | expo)
+- `--framework`(`-f`) : Framework type (expo)
 - `--binary-version`: The version of the binary app that the CodePush update is targeting.
 - `--app-version`: The version of the CodePush update itself.
 
@@ -394,12 +394,13 @@ Create a CodePush bundle file.
 npx code-push bundle --platform android --entry-file index.js
 
 # Expo project
-npx code-push bundle --type expo --platform android --entry-file index.js
+npx code-push bundle --framework expo --platform android --entry-file index.js
 ```
-- `--type`: Project type (react-native (default) | expo)
+- `--framework`(`-f`): Framework type (expo)
 
 By default, the bundle file is created in the `/build/bundleOutput` directory.
 
->[!NOTE] For Expo projects, the CLI uses `expo export:embed` command for bundling instead of React Native's bundle command.
+> [!NOTE]
+> For Expo projects, the CLI uses `expo export:embed` command for bundling instead of React Native's bundle command.
 
 (The file name represents a hash value of the bundle content.)

--- a/cli/commands/bundleCommand/bundleCodePush.js
+++ b/cli/commands/bundleCommand/bundleCodePush.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const { prepareToBundleJS } = require('../../functions/prepareToBundleJS');
 const { runReactNativeBundleCommand } = require('../../functions/runReactNativeBundleCommand');
+const { runExpoBundleCommand } = require('../../functions/runExpoBundleCommand');
 const { getReactTempDir } = require('../../functions/getReactTempDir');
 const { runHermesEmitBinaryCommand } = require('../../functions/runHermesEmitBinaryCommand');
 const { makeCodePushBundle } = require('../../functions/makeCodePushBundle');
 const { ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../constant');
 
 /**
+ * @param type {string} 'react-native' | 'expo'
  * @param platform {string} 'ios' | 'android'
  * @param outputRootPath {string}
  * @param entryFile {string}
@@ -15,6 +17,7 @@ const { ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../constant');
  * @return {Promise<string>} CodePush bundle file name (equals to packageHash)
  */
 async function bundleCodePush(
+  type = 'react-native',
   platform = 'ios',
   outputRootPath = ROOT_OUTPUT_DIR,
   entryFile = ENTRY_FILE,
@@ -32,13 +35,24 @@ async function bundleCodePush(
 
     prepareToBundleJS({ deleteDirs: [outputRootPath, getReactTempDir()], makeDir: OUTPUT_CONTENT_PATH });
 
-    runReactNativeBundleCommand(
-      _jsBundleName,
-      OUTPUT_CONTENT_PATH,
-      platform,
-      SOURCEMAP_OUTPUT,
-      entryFile,
-    );
+    if (type === 'react-native') {
+      runReactNativeBundleCommand(
+        _jsBundleName,
+        OUTPUT_CONTENT_PATH,
+        platform,
+        SOURCEMAP_OUTPUT,
+        entryFile,
+      );
+    } else if (type === 'expo') {
+      runExpoBundleCommand(
+        _jsBundleName,
+        OUTPUT_CONTENT_PATH,
+        platform,
+        SOURCEMAP_OUTPUT,
+        entryFile,
+      );
+    }
+
     console.log('log: JS bundling complete');
 
     await runHermesEmitBinaryCommand(

--- a/cli/commands/bundleCommand/bundleCodePush.js
+++ b/cli/commands/bundleCommand/bundleCodePush.js
@@ -8,7 +8,7 @@ const { makeCodePushBundle } = require('../../functions/makeCodePushBundle');
 const { ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../constant');
 
 /**
- * @param type {string} 'react-native' | 'expo'
+ * @param framework {string|undefined} 'expo'
  * @param platform {string} 'ios' | 'android'
  * @param outputRootPath {string}
  * @param entryFile {string}
@@ -17,7 +17,7 @@ const { ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../constant');
  * @return {Promise<string>} CodePush bundle file name (equals to packageHash)
  */
 async function bundleCodePush(
-  type = 'react-native',
+  framework,
   platform = 'ios',
   outputRootPath = ROOT_OUTPUT_DIR,
   entryFile = ENTRY_FILE,
@@ -35,16 +35,16 @@ async function bundleCodePush(
 
     prepareToBundleJS({ deleteDirs: [outputRootPath, getReactTempDir()], makeDir: OUTPUT_CONTENT_PATH });
 
-    if (type === 'react-native') {
-      runReactNativeBundleCommand(
+    if (framework === 'expo') {
+      runExpoBundleCommand(
         _jsBundleName,
         OUTPUT_CONTENT_PATH,
         platform,
         SOURCEMAP_OUTPUT,
         entryFile,
       );
-    } else if (type === 'expo') {
-      runExpoBundleCommand(
+    } else {
+      runReactNativeBundleCommand(
         _jsBundleName,
         OUTPUT_CONTENT_PATH,
         platform,

--- a/cli/commands/bundleCommand/index.js
+++ b/cli/commands/bundleCommand/index.js
@@ -4,7 +4,7 @@ const { OUTPUT_BUNDLE_DIR, ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../consta
 
 program.command('bundle')
     .description('Creates a CodePush bundle file (assumes Hermes is enabled).')
-    .addOption(new Option('-t, --type <type>', 'project type (react-native | expo)').choices(['react-native', 'expo']).default('react-native'))
+    .addOption(new Option('-f, --framework <type>', 'framework type (expo)').choices(['expo']))
     .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
     .option('-o, --output-path <string>', 'path to output root directory', ROOT_OUTPUT_DIR)
     .option('-e, --entry-file <string>', 'path to JS/TS entry file', ENTRY_FILE)
@@ -12,7 +12,7 @@ program.command('bundle')
     .option('--output-bundle-dir <string>', 'name of directory containing the bundle file created by the "bundle" command', OUTPUT_BUNDLE_DIR)
     /**
      * @param {Object} options
-     * @param {string} options.type
+     * @param {string} options.framework
      * @param {string} options.platform
      * @param {string} options.outputPath
      * @param {string} options.entryFile
@@ -22,7 +22,7 @@ program.command('bundle')
      */
     .action((options) => {
         bundleCodePush(
-            options.type,
+            options.framework,
             options.platform,
             options.outputPath,
             options.entryFile,

--- a/cli/commands/bundleCommand/index.js
+++ b/cli/commands/bundleCommand/index.js
@@ -4,6 +4,7 @@ const { OUTPUT_BUNDLE_DIR, ROOT_OUTPUT_DIR, ENTRY_FILE } = require('../../consta
 
 program.command('bundle')
     .description('Creates a CodePush bundle file (assumes Hermes is enabled).')
+    .addOption(new Option('-t, --type <type>', 'project type (react-native | expo)').choices(['react-native', 'expo']).default('react-native'))
     .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
     .option('-o, --output-path <string>', 'path to output root directory', ROOT_OUTPUT_DIR)
     .option('-e, --entry-file <string>', 'path to JS/TS entry file', ENTRY_FILE)
@@ -11,6 +12,7 @@ program.command('bundle')
     .option('--output-bundle-dir <string>', 'name of directory containing the bundle file created by the "bundle" command', OUTPUT_BUNDLE_DIR)
     /**
      * @param {Object} options
+     * @param {string} options.type
      * @param {string} options.platform
      * @param {string} options.outputPath
      * @param {string} options.entryFile
@@ -20,6 +22,7 @@ program.command('bundle')
      */
     .action((options) => {
         bundleCodePush(
+            options.type,
             options.platform,
             options.outputPath,
             options.entryFile,

--- a/cli/commands/releaseCommand/index.js
+++ b/cli/commands/releaseCommand/index.js
@@ -7,7 +7,7 @@ program.command('release')
     .description('Deploys a new CodePush update for a target binary app.\nAfter creating the CodePush bundle, it uploads the file and updates the ReleaseHistory information.\n`bundleUploader`, `getReleaseHistory`, and `setReleaseHistory` functions should be implemented in the config file.')
     .requiredOption('-b, --binary-version <string>', '(Required) The target binary version')
     .requiredOption('-v, --app-version <string>', '(Required) The app version to be released. It must be greater than the binary version.')
-    .addOption(new Option('-t, --type <type>', 'project type (react-native | expo)').choices(['react-native', 'expo']).default('react-native'))
+    .addOption(new Option('-f, --framework <type>', 'framework type (expo)').choices(['expo']))
     .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
     .option('-i, --identifier <string>', 'reserved characters to distinguish the release.')
     .option('-c, --config <path>', 'set config file name (JS/TS)', CONFIG_FILE_NAME)
@@ -23,7 +23,7 @@ program.command('release')
      * @param {Object} options
      * @param {string} options.binaryVersion
      * @param {string} options.appVersion
-     * @param {string} options.type
+     * @param {string} options.framework
      * @param {string} options.platform
      * @param {string} options.identifier
      * @param {string} options.config
@@ -46,7 +46,7 @@ program.command('release')
             config.setReleaseHistory,
             options.binaryVersion,
             options.appVersion,
-            options.type,
+            options.framework,
             options.platform,
             options.identifier,
             options.outputPath,

--- a/cli/commands/releaseCommand/index.js
+++ b/cli/commands/releaseCommand/index.js
@@ -7,6 +7,7 @@ program.command('release')
     .description('Deploys a new CodePush update for a target binary app.\nAfter creating the CodePush bundle, it uploads the file and updates the ReleaseHistory information.\n`bundleUploader`, `getReleaseHistory`, and `setReleaseHistory` functions should be implemented in the config file.')
     .requiredOption('-b, --binary-version <string>', '(Required) The target binary version')
     .requiredOption('-v, --app-version <string>', '(Required) The app version to be released. It must be greater than the binary version.')
+    .addOption(new Option('-t, --type <type>', 'project type (react-native | expo)').choices(['react-native', 'expo']).default('react-native'))
     .addOption(new Option('-p, --platform <type>', 'platform').choices(['ios', 'android']).default('ios'))
     .option('-i, --identifier <string>', 'reserved characters to distinguish the release.')
     .option('-c, --config <path>', 'set config file name (JS/TS)', CONFIG_FILE_NAME)
@@ -22,6 +23,7 @@ program.command('release')
      * @param {Object} options
      * @param {string} options.binaryVersion
      * @param {string} options.appVersion
+     * @param {string} options.type
      * @param {string} options.platform
      * @param {string} options.identifier
      * @param {string} options.config
@@ -44,6 +46,7 @@ program.command('release')
             config.setReleaseHistory,
             options.binaryVersion,
             options.appVersion,
+            options.type,
             options.platform,
             options.identifier,
             options.outputPath,

--- a/cli/commands/releaseCommand/release.js
+++ b/cli/commands/releaseCommand/release.js
@@ -25,6 +25,7 @@ const { addToReleaseHistory } = require("./addToReleaseHistory");
  *   ): Promise<void>}
  * @param binaryVersion {string}
  * @param appVersion {string}
+ * @param type {string} 'react-native' | 'expo'
  * @param platform {"ios" | "android"}
  * @param identifier {string?}
  * @param outputPath {string}
@@ -43,6 +44,7 @@ async function release(
     setReleaseHistory,
     binaryVersion,
     appVersion,
+    type = 'react-native',
     platform,
     identifier,
     outputPath,
@@ -56,7 +58,7 @@ async function release(
 ) {
     const bundleFileName = skipBundle
         ? readBundleFileNameFrom(bundleDirectory)
-        : await bundleCodePush(platform, outputPath, entryFile, jsBundleName, bundleDirectory);
+        : await bundleCodePush(type, platform, outputPath, entryFile, jsBundleName, bundleDirectory);
     const bundleFilePath = `${bundleDirectory}/${bundleFileName}`;
 
     const downloadUrl = await (async () => {

--- a/cli/commands/releaseCommand/release.js
+++ b/cli/commands/releaseCommand/release.js
@@ -25,7 +25,7 @@ const { addToReleaseHistory } = require("./addToReleaseHistory");
  *   ): Promise<void>}
  * @param binaryVersion {string}
  * @param appVersion {string}
- * @param type {string} 'react-native' | 'expo'
+ * @param framework {string|undefined} 'expo'
  * @param platform {"ios" | "android"}
  * @param identifier {string?}
  * @param outputPath {string}
@@ -44,7 +44,7 @@ async function release(
     setReleaseHistory,
     binaryVersion,
     appVersion,
-    type = 'react-native',
+    framework,
     platform,
     identifier,
     outputPath,
@@ -58,7 +58,7 @@ async function release(
 ) {
     const bundleFileName = skipBundle
         ? readBundleFileNameFrom(bundleDirectory)
-        : await bundleCodePush(type, platform, outputPath, entryFile, jsBundleName, bundleDirectory);
+        : await bundleCodePush(framework, platform, outputPath, entryFile, jsBundleName, bundleDirectory);
     const bundleFilePath = `${bundleDirectory}/${bundleFileName}`;
 
     const downloadUrl = await (async () => {

--- a/cli/functions/runExpoBundleCommand.js
+++ b/cli/functions/runExpoBundleCommand.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const shell = require('shelljs');
+
+/**
+ * Run `expo bundle` CLI command
+ *
+ * @param bundleName {string} JS bundle file name
+ * @param entryFile {string} App code entry file name (default: index.ts)
+ * @param outputPath {string} Path to output JS bundle file and assets
+ * @param platform {string} Platform (ios | android)
+ * @param sourcemapOutput {string} Path to output sourcemap file (Warning: if sourcemapOutput points to the outputPath, the sourcemap will be included in the CodePush bundle and increase the deployment size)
+ * @return {void}
+ */
+function runExpoBundleCommand(
+    bundleName,
+    outputPath,
+    platform,
+    sourcemapOutput,
+    entryFile,
+) {
+    /**
+     * @return {string}
+     */
+    function getCliPath() {
+        return path.join('node_modules', '.bin', 'expo');
+    }
+
+    /**
+     * @type {string[]}
+     */
+    const expoBundleArgs = [
+        'export:embed',
+        '--assets-dest',
+        outputPath,
+        '--bundle-output',
+        path.join(outputPath, bundleName),
+        '--dev',
+        'false',
+        '--entry-file',
+        entryFile,
+        '--platform',
+        platform,
+        '--sourcemap-output',
+        sourcemapOutput,
+        '--reset-cache',
+    ];
+
+    console.log('Running "expo export:embed" command:\n');
+
+    shell.exec(`${getCliPath()} ${expoBundleArgs.join(' ')}`);
+}
+
+module.exports = { runExpoBundleCommand };


### PR DESCRIPTION
## 📝 Overview
Adds Expo project support to the code-push CLI, enabling CodePush functionality for Expo projects alongside existing React Native projects.

- Related issue: https://github.com/Soomgo-Mobile/react-native-code-push/issues/72

## ✨ What's Added
- **framework option**: Added `-f, --framework` parameter with choices `expo` (only expo)
- **Expo bundle command**: Implemented `runExpoBundleCommand` function using `expo export:embed`
- **Unified CLI interface**: Both `bundle` and `release` commands now support both project types
- **Backward compatibility**: Maintains full compatibility with existing React Native projects (default behavior unchanged)

## 🔧 Changes Made

### 1. Enhanced CLI Commands
- **Bundle Command** (`cli/commands/bundleCommand/index.js`)
  - Added `--framework` option with `expo` choices
  - Default remains `react-native` for backward compatibility

- **Release Command** (`cli/commands/releaseCommand/index.js`) 
  - Added `--framework` option support
  - Passes type parameter through the release pipeline

### 2. Core Bundle Logic (`cli/commands/bundleCommand/bundleCodePush.js`)
- Added `framework` parameter to `bundleCodePush` function
- Conditional bundling based on project type:
  - `react-native`(default): Uses existing `runReactNativeBundleCommand`
  - `expo`: Uses new `runExpoBundleCommand`

### 3. New Expo Bundle Function (`cli/functions/runExpoBundleCommand.js`)
- Implements Expo-specific bundling using `expo export:embed`
- Mirrors React Native bundle command parameters
- Uses appropriate Expo CLI arguments for CodePush compatibility

### 4. Release Pipeline Updates (`cli/commands/releaseCommand/release.js`)
- Updated `release` function to accept and pass through `type` parameter
- Maintains existing functionality while supporting Expo projects

### 5. Documentation Updates (`README.md`)
- Added Expo usage examples to release and bundle command sections
- Added `--framework` parameter bundle, release cli description

## 🎯 Usage Examples

### For React Native Projects (unchanged)
```bash
npx code-push bundle --platform android
npx code-push release --binary-version 1.0.0 --app-version 1.0.1 --platform ios 
```

### For Expo Projects (new)
```bash
npx code-push bundle --platform android --framework expo
npx code-push release --binary-version 1.0.0 --app-version 1.0.1 --framework expo
```

## ✅ Testing
- [x] Tested Expo bundling with `expo export:embed`
- [x] Confirmed CLI parameter parsing works correctly

## 🔄 Breaking Changes
**None** - This is a fully backward compatible addition. All existing commands continue to work exactly as before.

## 📋 Related Work
- Expo plugin: https://github.com/Soomgo-Mobile/react-native-code-push/pull/74