### PR TITLE
mod!: simplify and remove legacy code for RN 0.73

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,9 @@
 
 ### 🚀 New Architecture support
 
-Tested on the React Native template apps
+Supports React Native 0.74 ~ 0.80.
 
-| RN Version | Old Architecture | New Architecture | New Architecture Bridgeless |
-|--------|--------|--------|--------|
-| 0.73.11 | ✅ | ✅ | Unsupported |
-| 0.74.7 | ✅ | ✅ | ✅ |
-| 0.75.5 | ✅ | ✅ | ✅ |
-| 0.76.7 | ✅ | ✅ | ✅ |
-| 0.77.1 | ✅ | ✅ | ✅ | 
-| 0.78.0 | ✅ | ✅ | ✅ | 
-
+(Tested on the React Native CLI template apps)
 
 ## 🚗 Migration Guide
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -24,10 +24,6 @@
     private ** mReactHost; # bridgeless
     public void reload(...); # RN 0.74 and above
 }
-# RN 0.74 and above
--keepclassmembers class com.facebook.react.ReactActivity {
-    public ** getReactDelegate(...);
-}
 # bridgeless
 -keepclassmembers class com.facebook.react.defaults.DefaultReactHostDelegate {
     private ** jsBundleLoader;


### PR DESCRIPTION
This PR removes support for React Native 0.73.

### Test Plan
Verified with the React Native CLI template app using the following versions:
- 0.74.7, 0.76.7, 0.78.0, 0.79.5(new), 0.80.1(new)