### PR TITLE
fix: clarify usage of ignoreFailedUpdates in CodePushOptions

### DIFF
--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -49,6 +49,10 @@ export interface UpdateCheckResponse {
 
 export interface CodePushOptions extends SyncOptions {
     /**
+     * The `ignoreFailedUpdates` option is only available as an option for `CodePush.sync()`.
+     */
+    ignoreFailedUpdates?: never;
+    /**
      * Specifies when you would like to synchronize updates with the CodePush server.
      * Defaults to codePush.CheckFrequency.ON_APP_START.
      */


### PR DESCRIPTION
```ts
export default CodePush({
  releaseHistoryFetcher,
  ignoreFailedUpdates: false, // this should be removed because it's not working
})(App);

```

and `ignoreFailedUpdates` should be set as an option for the `CodePush.sync()` call.

```ts
CodePush.sync({
    ignoreFailedUpdates: false, // ✨ 
    // ...
});

```