### PR TITLE
mod(Runtime): Prevent corrupted updates by verifying package hash

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -265,6 +265,8 @@ public class CodePushUpdateManager {
                     CodePushUtils.log("Applying full update.");
                 }
 
+                CodePushUpdateUtils.verifyFolderHash(newUpdateFolderPath, newUpdateHash);
+
                 boolean isSignatureVerificationEnabled = (stringPublicKey != null);
 
                 String signaturePath = CodePushUpdateUtils.getSignatureFilePath(newUpdateFolderPath);
@@ -272,7 +274,6 @@ public class CodePushUpdateManager {
 
                 if (isSignatureVerificationEnabled) {
                     if (isSignatureAppearedInBundle) {
-                        CodePushUpdateUtils.verifyFolderHash(newUpdateFolderPath, newUpdateHash);
                         CodePushUpdateUtils.verifyUpdateSignature(newUpdateFolderPath, newUpdateHash, stringPublicKey);
                     } else {
                         throw new CodePushInvalidUpdateException(
@@ -288,11 +289,6 @@ public class CodePushUpdateManager {
                                 "Warning! JWT signature exists in codepush update but code integrity check couldn't be performed because there is no public key configured. " +
                                 "Please ensure that public key is properly configured within your application."
                         );
-                        CodePushUpdateUtils.verifyFolderHash(newUpdateFolderPath, newUpdateHash);
-                    } else {
-                        if (isDiffUpdate) {
-                            CodePushUpdateUtils.verifyFolderHash(newUpdateFolderPath, newUpdateHash);
-                        }
                     }
                 }
 

--- a/ios/CodePush/CodePushPackage.m
+++ b/ios/CodePush/CodePushPackage.m
@@ -237,27 +237,28 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                         }
 
                                                         CPLog((isDiffUpdate) ? @"Applying diff update." : @"Applying full update.");
-                                                        
+
+                                                        if (![CodePushUpdateUtils verifyFolderHash:newUpdateFolderPath
+                                                                                      expectedHash:newUpdateHash
+                                                                                             error:&error]) {
+                                                            CPLog(@"The update contents failed the data integrity check.");
+                                                            if (!error) {
+                                                                error = [CodePushErrorUtils errorWithMessage:@"The update contents failed the data integrity check."];
+                                                            }
+
+                                                            failCallback(error);
+                                                            return;
+                                                        } else {
+                                                            CPLog(@"The update contents succeeded the data integrity check.");
+                                                        }
+
                                                         BOOL isSignatureVerificationEnabled = (publicKey != nil);
-                                                        
+
                                                         NSString *signatureFilePath = [CodePushUpdateUtils getSignatureFilePath:newUpdateFolderPath];
                                                         BOOL isSignatureAppearedInBundle = [[NSFileManager defaultManager] fileExistsAtPath:signatureFilePath];
-                                                        
+
                                                         if (isSignatureVerificationEnabled) {
                                                             if (isSignatureAppearedInBundle) {
-                                                                if (![CodePushUpdateUtils verifyFolderHash:newUpdateFolderPath
-                                                                                              expectedHash:newUpdateHash
-                                                                                                     error:&error]) {
-                                                                    CPLog(@"The update contents failed the data integrity check.");
-                                                                    if (!error) {
-                                                                        error = [CodePushErrorUtils errorWithMessage:@"The update contents failed the data integrity check."];
-                                                                    }
-                                                                    
-                                                                    failCallback(error);
-                                                                    return;
-                                                                } else {
-                                                                    CPLog(@"The update contents succeeded the data integrity check.");
-                                                                }
                                                                 BOOL isSignatureValid = [CodePushUpdateUtils verifyUpdateSignatureFor:newUpdateFolderPath
                                                                                                                          expectedHash:newUpdateHash
                                                                                                                         withPublicKey:publicKey
@@ -283,29 +284,10 @@ static NSString *const UnzippedFolderName = @"unzipped";
                                                             }
                                                             
                                                         } else {
-                                                            BOOL needToVerifyHash;
                                                             if (isSignatureAppearedInBundle) {
                                                                 CPLog(@"Warning! JWT signature exists in codepush update but code integrity check couldn't be performed" \
                                                                       " because there is no public key configured. " \
                                                                       "Please ensure that public key is properly configured within your application.");
-                                                                needToVerifyHash = true;
-                                                            } else {
-                                                                needToVerifyHash = isDiffUpdate;
-                                                            }
-                                                            if(needToVerifyHash){
-                                                                if (![CodePushUpdateUtils verifyFolderHash:newUpdateFolderPath
-                                                                                              expectedHash:newUpdateHash
-                                                                                                     error:&error]) {
-                                                                    CPLog(@"The update contents failed the data integrity check.");
-                                                                    if (!error) {
-                                                                        error = [CodePushErrorUtils errorWithMessage:@"The update contents failed the data integrity check."];
-                                                                    }
-                                                                    
-                                                                    failCallback(error);
-                                                                    return;
-                                                                } else {
-                                                                    CPLog(@"The update contents succeeded the data integrity check.");
-                                                                }
                                                             }
                                                         }
                                                     } else {


### PR DESCRIPTION
To address rare reports of the error "Compiling JS failed: Buffer is smaller than the size state…" in production, the existing verification logic is now used to validate updates.
This error occurs in the [Hermes](https://github.com/facebook/hermes/blob/2311df6df0a8e2e4eb1d1d7f1ac135afab7541c8/lib/BCGen/HBC/BytecodeDataProvider.cpp#L104) engine during the initial validation of the JS bundle.

After downloading an update and extracting the CodePush bundle file, the hash is computed and compared with the hash stored in the release metadata.
The stored hash is generated by the `npx code-push` CLI tool using the same process as the app runtime.

If the update is invalid, the `CodePush.sync()` call is rejected and the `onSyncError` telemetry callback is triggered.