### PR TITLE
fix: error when setting up Expo plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "react-native.config.js",
     "app.plugin.js",
     "package.json",
-    "package-lock.json",
     "!ios/build",
     "!android/build",
     "!android/app/build",


### PR DESCRIPTION
closes #96 

I forgot to include the file for Expo plugin in the NPM package 😭 