### PR TITLE
fix(android): serialize download progress events

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -341,19 +341,28 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                 try {
                     JSONObject mutableUpdatePackage = CodePushUtils.convertReadableToJsonObject(updatePackage);
                     mUpdateManager.downloadPackage(mutableUpdatePackage, mCodePush.getAssetsBundleFileName(), new DownloadProgressCallback() {
-                        private boolean hasScheduledNextFrame = false;
-                        private DownloadProgress latestDownloadProgress = null;
+                        private volatile boolean hasScheduledNextFrame = false;
+                        private volatile DownloadProgress latestDownloadProgress = null;
+                        private final DownloadProgressEventDispatcher progressEventDispatcher = new DownloadProgressEventDispatcher(
+                                new DownloadProgressEventDispatcher.EventEmitter() {
+                                    @Override
+                                    public void emit(DownloadProgress downloadProgress) {
+                                        getReactApplicationContext()
+                                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                                .emit(CodePushConstants.DOWNLOAD_PROGRESS_EVENT_NAME, downloadProgress.createWritableMap());
+                                    }
+                                });
 
                         @Override
                         public void call(DownloadProgress downloadProgress) {
-                            if (!notifyProgress) {
+                            if (!notifyProgress || downloadProgress == null) {
                                 return;
                             }
 
                             latestDownloadProgress = downloadProgress;
                             // If the download is completed, synchronously send the last event.
-                            if (latestDownloadProgress.isCompleted()) {
-                                dispatchDownloadProgressEvent();
+                            if (downloadProgress.isCompleted()) {
+                                progressEventDispatcher.dispatch(downloadProgress);
                                 return;
                             }
 
@@ -368,21 +377,15 @@ public class CodePushNativeModule extends ReactContextBaseJavaModule {
                                     ReactChoreographer.getInstance().postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, new Choreographer.FrameCallback() {
                                         @Override
                                         public void doFrame(long frameTimeNanos) {
-                                            if (!latestDownloadProgress.isCompleted()) {
-                                                dispatchDownloadProgressEvent();
+                                            try {
+                                                progressEventDispatcher.dispatch(latestDownloadProgress);
+                                            } finally {
+                                                hasScheduledNextFrame = false;
                                             }
-
-                                            hasScheduledNextFrame = false;
                                         }
                                     });
                                 }
                             });
-                        }
-
-                        public void dispatchDownloadProgressEvent() {
-                            getReactApplicationContext()
-                                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                                    .emit(CodePushConstants.DOWNLOAD_PROGRESS_EVENT_NAME, latestDownloadProgress.createWritableMap());
                         }
                     });
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgress.java
@@ -27,4 +27,8 @@ class DownloadProgress {
     public boolean isCompleted() {
         return mTotalBytes == mReceivedBytes;
     }
+
+    long getReceivedBytes() {
+        return mReceivedBytes;
+    }
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressEventDispatcher.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressEventDispatcher.java
@@ -1,0 +1,23 @@
+package com.microsoft.codepush.react;
+
+class DownloadProgressEventDispatcher {
+    interface EventEmitter {
+        void emit(DownloadProgress downloadProgress);
+    }
+
+    private final EventEmitter mEventEmitter;
+    private long mLastDispatchedBytes = -1;
+
+    DownloadProgressEventDispatcher(EventEmitter eventEmitter) {
+        mEventEmitter = eventEmitter;
+    }
+
+    synchronized void dispatch(DownloadProgress downloadProgress) {
+        if (downloadProgress == null || downloadProgress.getReceivedBytes() <= mLastDispatchedBytes) {
+            return;
+        }
+
+        mEventEmitter.emit(downloadProgress);
+        mLastDispatchedBytes = downloadProgress.getReceivedBytes();
+    }
+}


### PR DESCRIPTION

## Background

An NPE occurred on Android while dispatching download progress events from a UI frame callback.

```text
java.lang.NullPointerException: Attempt to invoke virtual method 'com.facebook.react.bridge.WritableMap com.microsoft.codepush.react.i.a()' on a null object reference
        at com.microsoft.codepush.react.CodePushNativeModule$c$a.d(CodePushNativeModule.java:19)
        at com.microsoft.codepush.react.CodePushNativeModule$c$a$a$a.doFrame(CodePushNativeModule.java:19)
        at com.facebook.react.modules.core.ReactChoreographer.frameCallback$lambda$1(ReactChoreographer.kt:32)
        at com.facebook.react.modules.core.ReactChoreographer.a(ReactChoreographer.kt:1)
        at com.facebook.react.modules.core.e.doFrame(R8$$SyntheticClass:3)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1106)
        at android.view.Choreographer.doCallbacks(Choreographer.java:866)
        at android.view.Choreographer.doFrame(Choreographer.java:792)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1092)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:226)
        at android.os.Looper.loop(Looper.java:313)
        at android.app.ActivityThread.main(ActivityThread.java:8751)
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

Progress state was shared between the download and UI threads, and an earlier progress event could be delivered after the completion event.

## Changes

- Prevent the NPE by checking progress events for null before accessing them
- Safely handle progress state shared between threads
- Drop progress events whose values are less than or equal to the last dispatched value
- Preserve synchronous delivery of the final completion event
- No changes to the JavaScript API

## Verification

- Successfully compiled the Android release Java sources with React Native 0.85.3
- Verified 7 actual bundle downloads using a local E2E server
- Completed all downloads without an NPE across 36 progress events
- Every download reached its final byte count without duplicate or regressing progress events
