### PR TITLE
fix: restart the download progress stream on binary patch fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Please refer to the [CodePushOptions](https://github.com/Soomgo-Mobile/react-nat
 A `"fallback"` is not a failed update: the update is downloaded in full instead and installed as usual, so the result
 is there to be observed and nothing more. The library neither stores it nor sends it anywhere - an app that wants it in
 its telemetry sends it itself. A callback that throws never fails the update - the error is only logged to the console.
+A fallback also shows in `downloadProgressCallback`: the full download opens a second progress stream whose
+`receivedBytes` restarts from `0` against its own, larger `totalBytes`.
 
 Register it on `CodePush({ ... })` like the callbacks above and it covers every sync, whatever the `checkFrequency` is
 and including the `CodePush.sync()` calls you make yourself.

--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ Please refer to the [CodePushOptions](https://github.com/Soomgo-Mobile/react-nat
 A `"fallback"` is not a failed update: the update is downloaded in full instead and installed as usual, so the result
 is there to be observed and nothing more. The library neither stores it nor sends it anywhere - an app that wants it in
 its telemetry sends it itself. A callback that throws never fails the update - the error is only logged to the console.
-A fallback also shows in `downloadProgressCallback`: the full download opens a second progress stream whose
-`receivedBytes` restarts from `0` against its own, larger `totalBytes`.
+A fallback also shows in `downloadProgressCallback`: the full download reports a second progress stream that counts
+`receivedBytes` from zero again, against its own, larger `totalBytes`.
 
-Register it on `CodePush({ ... })` like the callbacks above and it covers every sync, whatever the `checkFrequency` is
+Register `onBinaryPatchResult` on `CodePush({ ... })` like the callbacks above and it covers every sync, whatever the `checkFrequency` is
 and including the `CodePush.sync()` calls you make yourself.
 
 ```typescript

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushNativeModule.java
@@ -338,7 +338,6 @@ public class CodePushNativeModule extends NativeCodePushSpec {
                     JSONObject mutableUpdatePackage = CodePushUtils.convertReadableToJsonObject(updatePackage);
                     JSONObject binaryPatchResult = mUpdateManager.downloadPackage(mutableUpdatePackage, mCodePush.getAssetsBundleFileName(), new DownloadProgressCallback() {
                         private volatile boolean hasScheduledNextFrame = false;
-                        private volatile DownloadProgress latestDownloadProgress = null;
                         private final DownloadProgressEventDispatcher progressEventDispatcher = new DownloadProgressEventDispatcher(
                                 new DownloadProgressEventDispatcher.EventEmitter() {
                                     @Override
@@ -348,15 +347,20 @@ public class CodePushNativeModule extends NativeCodePushSpec {
                                 });
 
                         @Override
+                        public void onDownloadStart() {
+                            progressEventDispatcher.reset();
+                        }
+
+                        @Override
                         public void call(DownloadProgress downloadProgress) {
                             if (!notifyProgress || downloadProgress == null) {
                                 return;
                             }
 
-                            latestDownloadProgress = downloadProgress;
+                            progressEventDispatcher.record(downloadProgress);
                             // If the download is completed, synchronously send the last event.
                             if (downloadProgress.isCompleted()) {
-                                progressEventDispatcher.dispatch(downloadProgress);
+                                progressEventDispatcher.dispatchLatest();
                                 return;
                             }
 
@@ -372,7 +376,7 @@ public class CodePushNativeModule extends NativeCodePushSpec {
                                         @Override
                                         public void doFrame(long frameTimeNanos) {
                                             try {
-                                                progressEventDispatcher.dispatch(latestDownloadProgress);
+                                                progressEventDispatcher.dispatchLatest();
                                             } finally {
                                                 hasScheduledNextFrame = false;
                                             }

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -260,7 +260,6 @@ public class CodePushUpdateManager {
 
         // Download the file while checking if it is a zip and notifying client of progress.
         try {
-            progressCallback.onDownloadStart();
             URL downloadUrl = new URL(downloadUrlString);
             connection = (HttpURLConnection) (downloadUrl.openConnection());
 
@@ -276,6 +275,9 @@ public class CodePushUpdateManager {
             connection.setRequestProperty("Accept-Encoding", "identity");
             bin = new BufferedInputStream(connection.getInputStream());
 
+            // Announced only once the response is flowing, so a connection that fails to
+            // open never announces an empty stream.
+            progressCallback.onDownloadStart();
             long totalBytes = connection.getContentLength();
             long receivedBytes = 0;
 

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushUpdateManager.java
@@ -260,6 +260,7 @@ public class CodePushUpdateManager {
 
         // Download the file while checking if it is a zip and notifying client of progress.
         try {
+            progressCallback.onDownloadStart();
             URL downloadUrl = new URL(downloadUrlString);
             connection = (HttpURLConnection) (downloadUrl.openConnection());
 
@@ -277,6 +278,12 @@ public class CodePushUpdateManager {
 
             long totalBytes = connection.getContentLength();
             long receivedBytes = 0;
+
+            if (totalBytes > 0) {
+                // The zero-received event hands the listener this download's total up front,
+                // so a fallback download shows as restarting rather than running backwards.
+                progressCallback.call(new DownloadProgress(totalBytes, 0));
+            }
 
             File downloadFolder = new File(getCodePushPath());
             downloadFolder.mkdirs();

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressCallback.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressCallback.java
@@ -1,5 +1,12 @@
 package com.microsoft.codepush.react;
 
 interface DownloadProgressCallback {
+    /**
+     * A download is starting its own progress stream: received bytes count from zero again,
+     * against this download's own total. A binary patch fallback makes this happen twice
+     * within one downloaded update.
+     */
+    void onDownloadStart();
+
     void call(DownloadProgress downloadProgress);
 }

--- a/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressEventDispatcher.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/DownloadProgressEventDispatcher.java
@@ -1,23 +1,44 @@
 package com.microsoft.codepush.react;
 
+/**
+ * Serializes progress events from the download thread and the UI frame callback into one
+ * monotonic stream per download: whatever order the two threads dispatch in, the JS side
+ * never sees the same download run backwards. The latest progress lives here rather than
+ * with the caller so that reading it and dispatching it happen under one lock.
+ */
 class DownloadProgressEventDispatcher {
     interface EventEmitter {
         void emit(DownloadProgress downloadProgress);
     }
 
     private final EventEmitter mEventEmitter;
+    private DownloadProgress mLatestDownloadProgress = null;
     private long mLastDispatchedBytes = -1;
 
     DownloadProgressEventDispatcher(EventEmitter eventEmitter) {
         mEventEmitter = eventEmitter;
     }
 
-    synchronized void dispatch(DownloadProgress downloadProgress) {
-        if (downloadProgress == null || downloadProgress.getReceivedBytes() <= mLastDispatchedBytes) {
+    synchronized void record(DownloadProgress downloadProgress) {
+        mLatestDownloadProgress = downloadProgress;
+    }
+
+    synchronized void dispatchLatest() {
+        if (mLatestDownloadProgress == null || mLatestDownloadProgress.getReceivedBytes() <= mLastDispatchedBytes) {
             return;
         }
 
-        mEventEmitter.emit(downloadProgress);
-        mLastDispatchedBytes = downloadProgress.getReceivedBytes();
+        mEventEmitter.emit(mLatestDownloadProgress);
+        mLastDispatchedBytes = mLatestDownloadProgress.getReceivedBytes();
+    }
+
+    /**
+     * Forgets the download dispatched so far. The next download counts its bytes from zero,
+     * and without the reset the monotonic guard would swallow its events as the previous
+     * download running backwards.
+     */
+    synchronized void reset() {
+        mLatestDownloadProgress = null;
+        mLastDispatchedBytes = -1;
     }
 }

--- a/android/app/src/test/java/com/microsoft/codepush/react/CodePushUpdateManagerBinaryPatchTest.java
+++ b/android/app/src/test/java/com/microsoft/codepush/react/CodePushUpdateManagerBinaryPatchTest.java
@@ -147,6 +147,10 @@ public class CodePushUpdateManagerBinaryPatchTest {
     private static DownloadProgressCallback ignoreProgress() {
         return new DownloadProgressCallback() {
             @Override
+            public void onDownloadStart() {
+            }
+
+            @Override
             public void call(DownloadProgress downloadProgress) {
             }
         };

--- a/android/app/src/test/java/com/microsoft/codepush/react/CodePushUpdateManagerDownloadTest.java
+++ b/android/app/src/test/java/com/microsoft/codepush/react/CodePushUpdateManagerDownloadTest.java
@@ -161,6 +161,42 @@ public class CodePushUpdateManagerDownloadTest {
         assertFallbackResult(patchResult, BinaryPatchResult.REASON_PACKAGE_VERIFICATION_FAILED);
     }
 
+    @Test
+    public void announcesEachDownloadOfAFallbackAsItsOwnProgressStream() throws IOException {
+        byte[] fullArchive = zipOf(fullArchiveContents());
+        String patchUrl = serve("/patch.zip", ERROR_PAGE);
+        String fullUrl = serve("/full.zip", fullArchive);
+        final List<List<Long>> streams = new ArrayList<>();
+        final List<Long> completedBytes = new ArrayList<>();
+
+        updateManager(applierWriting(TARGET_BUNDLE)).downloadPackage(
+                updatePackage(fullUrl, patchUrl), BUNDLE_FILE_NAME, new DownloadProgressCallback() {
+                    @Override
+                    public void onDownloadStart() {
+                        streams.add(new ArrayList<Long>());
+                    }
+
+                    @Override
+                    public void call(DownloadProgress downloadProgress) {
+                        streams.get(streams.size() - 1).add(downloadProgress.getReceivedBytes());
+                        if (downloadProgress.isCompleted()) {
+                            completedBytes.add(downloadProgress.getReceivedBytes());
+                        }
+                    }
+                });
+
+        assertEquals("each download announces a stream of its own", 2, streams.size());
+        for (List<Long> stream : streams) {
+            assertEquals("a stream opens by putting its total on the table at zero received",
+                    Long.valueOf(0), stream.get(0));
+            for (int i = 1; i < stream.size(); i++) {
+                assertTrue("a stream never runs backwards", stream.get(i) >= stream.get(i - 1));
+            }
+        }
+        assertEquals("both downloads complete at the size of the body they served",
+                Arrays.asList((long) ERROR_PAGE.length, (long) fullArchive.length), completedBytes);
+    }
+
     /** The result of a download the update had to be downloaded in full for. */
     private static void assertFallbackResult(JSONObject patchResult, String expectedReason) {
         assertEquals("fallback", patchResult.optString("status", null));
@@ -393,6 +429,10 @@ public class CodePushUpdateManagerDownloadTest {
 
     private static DownloadProgressCallback ignoreProgress() {
         return new DownloadProgressCallback() {
+            @Override
+            public void onDownloadStart() {
+            }
+
             @Override
             public void call(DownloadProgress downloadProgress) {
             }

--- a/android/app/src/test/java/com/microsoft/codepush/react/DownloadProgressEventDispatcherTest.java
+++ b/android/app/src/test/java/com/microsoft/codepush/react/DownloadProgressEventDispatcherTest.java
@@ -1,0 +1,80 @@
+package com.microsoft.codepush.react;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The dispatcher is the seam between the download thread and the UI frame callback. These
+ * pin the property the two threads rely on: per download, the JS side sees one monotonic
+ * stream, and after a reset the next download's stream starts fresh instead of being
+ * mistaken for the previous one running backwards.
+ */
+public class DownloadProgressEventDispatcherTest {
+
+    private final List<Long> mEmittedBytes = new ArrayList<>();
+    private final DownloadProgressEventDispatcher mDispatcher = new DownloadProgressEventDispatcher(
+            new DownloadProgressEventDispatcher.EventEmitter() {
+                @Override
+                public void emit(DownloadProgress downloadProgress) {
+                    mEmittedBytes.add(downloadProgress.getReceivedBytes());
+                }
+            });
+
+    @Test
+    public void aFrameCallbackWithNothingRecordedEmitsNothing() {
+        mDispatcher.dispatchLatest();
+
+        assertEquals(Collections.emptyList(), mEmittedBytes);
+    }
+
+    @Test
+    public void emitsOnlyTheLatestRecordedProgress() {
+        mDispatcher.record(new DownloadProgress(100, 60));
+        mDispatcher.record(new DownloadProgress(100, 80));
+
+        mDispatcher.dispatchLatest();
+
+        assertEquals(Arrays.asList(80L), mEmittedBytes);
+    }
+
+    @Test
+    public void aFrameCallbackFiringAfterTheCompletionEventEmitsNothingMore() {
+        mDispatcher.record(new DownloadProgress(100, 90));
+        mDispatcher.dispatchLatest();
+        mDispatcher.record(new DownloadProgress(100, 100));
+        mDispatcher.dispatchLatest();
+
+        // The frame callback that was already scheduled when the download completed.
+        mDispatcher.dispatchLatest();
+
+        assertEquals(Arrays.asList(90L, 100L), mEmittedBytes);
+    }
+
+    @Test
+    public void aResetLetsTheNextDownloadCountFromZeroAgain() {
+        mDispatcher.record(new DownloadProgress(100, 100));
+        mDispatcher.dispatchLatest();
+
+        mDispatcher.reset();
+        mDispatcher.record(new DownloadProgress(5000, 10));
+        mDispatcher.dispatchLatest();
+
+        assertEquals(Arrays.asList(100L, 10L), mEmittedBytes);
+    }
+
+    @Test
+    public void progressRecordedBeforeAResetIsNotEmittedAfterIt() {
+        mDispatcher.record(new DownloadProgress(100, 100));
+
+        mDispatcher.reset();
+        mDispatcher.dispatchLatest();
+
+        assertEquals(Collections.emptyList(), mEmittedBytes);
+    }
+}

--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -164,11 +164,11 @@ Called when the sync process moves from one stage to another in the overall upda
 
 Called periodically when an available update is being downloaded from the CodePush server. The method is called with a `DownloadProgress` object, which contains the following two properties:
 
-* __totalBytes__ *(Number)* - The total number of bytes expected to be received for this update (i.e. the size of the set of files which changed from the previous release).
+* __totalBytes__ *(Number)* - The total number of bytes expected to be received for this download (for a regular update, the size of the set of files which changed from the previous release).
 
 * __receivedBytes__ *(Number)* - The number of bytes downloaded thus far, which can be used to track download progress.
 
-Each download reports a stream of its own, opened by an event with `receivedBytes` at `0`. When a release ships with a binary patch that cannot be applied, the update is downloaded again in full, so one update can report two such streams - the second with the full download's larger `totalBytes`.
+Each download reports a progress stream of its own: `receivedBytes` counts from zero against that download's own `totalBytes`. When a release ships with a binary patch that cannot be applied, the update is downloaded again in full, so one update can report two streams - the second with the full download's larger `totalBytes`.
 
 #### codePush.allowRestart
 
@@ -460,7 +460,7 @@ In addition to the options, the `sync` method also accepts several optional func
 
 * __downloadProgressCallback__ *((progress: DownloadProgress) => void)* - Called periodically when an available update is being downloaded from the CodePush server. The method is called with a `DownloadProgress` object, which contains the following two properties:
 
-    * __totalBytes__ *(Number)* - The total number of bytes expected to be received for this update (i.e. the size of the set of files which changed from the previous release).
+    * __totalBytes__ *(Number)* - The total number of bytes expected to be received for this download (for a regular update, the size of the set of files which changed from the previous release).
 
     * __receivedBytes__ *(Number)* - The number of bytes downloaded thus far, which can be used to track download progress.
 

--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -168,6 +168,8 @@ Called periodically when an available update is being downloaded from the CodePu
 
 * __receivedBytes__ *(Number)* - The number of bytes downloaded thus far, which can be used to track download progress.
 
+Each download reports a stream of its own, opened by an event with `receivedBytes` at `0`. When a release ships with a binary patch that cannot be applied, the update is downloaded again in full, so one update can report two such streams - the second with the full download's larger `totalBytes`.
+
 #### codePush.allowRestart
 
 ```javascript
@@ -461,6 +463,8 @@ In addition to the options, the `sync` method also accepts several optional func
     * __totalBytes__ *(Number)* - The total number of bytes expected to be received for this update (i.e. the size of the set of files which changed from the previous release).
 
     * __receivedBytes__ *(Number)* - The number of bytes downloaded thus far, which can be used to track download progress.
+
+    See [codePushDownloadDidProgress](#codepushdownloaddidprogress-event-hook) for how a binary patch fallback reports a second download.
 
 * __handleBinaryVersionMismatchCallback__ *((update: RemotePackage) => void)* - 
 Called when there are any binary update available. The method is called with a [`RemotePackage`](#remotepackage) object. Refer to [codePush.checkForUpdate](#codepushcheckforupdate) section for more details.

--- a/ios/CodePush/CodePush.mm
+++ b/ios/CodePush/CodePush.mm
@@ -743,7 +743,7 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
             // own - the full archive after a binary patch fallback. The pause left over
             // from the finished patch download would swallow that whole stream, so frame
             // observation resumes here and the throttle forgets the previous stream.
-            if (receivedContentLength < _latestReceivedConentLength) {
+            if (notifyProgress && receivedContentLength < _latestReceivedConentLength) {
                 self.paused = NO;
                 _lastProgressEventTime = 0;
             }

--- a/ios/CodePush/CodePush.mm
+++ b/ios/CodePush/CodePush.mm
@@ -739,6 +739,14 @@ RCT_EXPORT_METHOD(downloadUpdate:(NSDictionary*)updatePackage
         operationQueue:_methodQueue
         // The download is progressing forward
         progressCallback:^(long long expectedContentLength, long long receivedContentLength) {
+            // Received bytes only run backwards when a new download starts a stream of its
+            // own - the full archive after a binary patch fallback. The pause left over
+            // from the finished patch download would swallow that whole stream, so frame
+            // observation resumes here and the throttle forgets the previous stream.
+            if (receivedContentLength < _latestReceivedConentLength) {
+                self.paused = NO;
+                _lastProgressEventTime = 0;
+            }
             // Update the download progress so that the frame observer can notify the JS side
             _latestExpectedContentLength = expectedContentLength;
             _latestReceivedConentLength = receivedContentLength;

--- a/ios/CodePush/CodePushDownloadHandler.m
+++ b/ios/CodePush/CodePushDownloadHandler.m
@@ -61,6 +61,12 @@ failCallback:(void (^)(NSError *err))failCallback {
     }
     
     self.expectedContentLength = response.expectedContentLength;
+    if (self.expectedContentLength > 0) {
+        // Each download opens its own progress stream. The zero-received event hands the
+        // listener the new total up front, so the full download after a binary patch
+        // fallback shows as restarting rather than running backwards.
+        self.progressCallback(self.expectedContentLength, 0);
+    }
     [self.outputFileStream open];
 }
 

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -162,7 +162,9 @@ export interface CodePushOptions extends SyncOptions {
 
 export interface DownloadProgress {
     /**
-     * The total number of bytes expected to be received for this update.
+     * The total number of bytes expected to be received for this download. An update
+     * published with a binary patch can be downloaded twice: when applying the patch
+     * fails, the full archive is downloaded as a second stream with its own total.
      */
     totalBytes: number;
 


### PR DESCRIPTION
## Background

When a release ships with a binary patch and applying it fails, CodePush falls back to downloading the full update through the same progress callback. Both platforms mishandled that second download:

- **Android**: #148 made the dispatcher drop any progress event that doesn't advance past the highest `receivedBytes` it has dispatched. That high-water mark never resets between downloads, so every event from the fallback download was swallowed until the fallback's `receivedBytes` exceeded the patch size. The first event that got through then dropped progress from 100% (of the patch) to a few percent (of the full archive).
- **iOS**: completing the patch download pauses the frame observer, and nothing resumes it. On the legacy bridge, the entire fallback download therefore reported no intermediate progress.

## Changes

- Each download now has its own progress stream: `receivedBytes` starts at zero and advances against that download's own `totalBytes`.
- **Android**: `downloadAndInstallPackage` signals the stream boundary via `DownloadProgressCallback.onDownloadStart()` once the connection is open, and the dispatcher resets its `receivedBytes` high-water mark there. Tracking the latest progress also moved into the dispatcher so state updates and dispatch happen under one lock. The serialization guarantees from #148 (no NPE and nothing delivered after the completion event) are preserved and now covered by unit tests.
- **iOS**: the download handler reports a zero-received event when a response with a known length arrives, and progress observation resumes when `receivedBytes` decreases, which only occurs when a new stream starts. Restart detection is gated on `notifyProgress`, so downloads without a progress listener remain silent.
- Documented the per-download stream contract in `docs/api-js.md`, the README fallback section, and the `DownloadProgress` typings.
- No JavaScript API changes: consumers continue to receive `{ totalBytes, receivedBytes }` and can detect the fallback by the restart or ignore it.

## Verification

- **Android**: 37 JVM unit tests pass (`:testDebugUnitTest`), including 5 new dispatcher tests covering the #148 serialization guarantees and reset behavior, plus a new download test asserting that a fallback reports two streams, each starting at zero and completing at its own body size.
- **iOS**: the RN0840 (RN 0.84, new architecture) Debug simulator build succeeds; both changed files compile for arm64/x86_64 with no new warning classes.
- Checked concurrency behavior against the #148 regression: under every interleaving of the download thread and UI frame callback, progress within a single download only moves forward.