### PR TITLE
fix: bundle updates unminified to match the binary

### DIFF
--- a/cli/functions/runExpoBundleCommand.ts
+++ b/cli/functions/runExpoBundleCommand.ts
@@ -32,6 +32,10 @@ export function runExpoBundleCommand(
         'false',
         '--entry-file',
         entryFile,
+        // Same reason as `runReactNativeBundleCommand`: the native build embeds an
+        // unminified bundle, and diverging from it inflates every binary patch.
+        '--minify',
+        'false',
         '--platform',
         platform,
         '--sourcemap-output',

--- a/cli/functions/runReactNativeBundleCommand.ts
+++ b/cli/functions/runReactNativeBundleCommand.ts
@@ -38,6 +38,16 @@ export function runReactNativeBundleCommand(
         'false',
         '--entry-file',
         entryFile,
+        /**
+         * Match React Native's Hermes builds, which disable JS minification. Minifying an
+         * update barely changes how large its bytecode is, but it changes how that bytecode
+         * is laid out - enough that a binary patch against an unminified binary costs far
+         * more than the source change does.
+         *
+         * Listed before the caller's options so an explicit `--minify` still wins.
+         */
+        '--minify',
+        'false',
         '--platform',
         platform,
         '--sourcemap-output',


### PR DESCRIPTION
## Background

React Native disables JS minification for Hermes builds, so the JS bundle embedded in an app binary is never minified. As of RN 0.83.2:

- `scripts/react-native-xcode.sh` — `# Hermes doesn't require JS minification.` then `EXTRA_ARGS+=("--minify" "false")`
- `@react-native/gradle-plugin` `TaskConfiguration.kt` — `minifyEnabled.set(!isHermesEnabledInThisVariant)`

This CLI passed no `--minify` flag, and the bundler defaults it to `!dev`. With `--dev false` hardcoded, every update was minified while the binary it patches was not.

Both bundles run, and they come out nearly the same size, which is why this went unnoticed. But minification inlines Babel helpers the binary's bundle still carries, so the two hold different Hermes function tables. Function ids and bytecode offsets then shift across the whole file, and the binary patch has to carry all of it — even though `-base-bytecode` had already aligned the string table perfectly.

Measured on an 18 MB Android bundle whose source diff was 23 lines:

| | base (in the binary) | update |
| --- | ---: | ---: |
| `functionCount` | 98,851 | 95,520 |
| `_callSuper` | 518 | 74 |
| `_interopRequireWildcard` | 4,134 | 2,613 |

Running `hdiffz` per Hermes section shows where the 1.73 MB patch went:

| section | patch |
| --- | ---: |
| function headers | 637,776 |
| bytecode | 1,068,462 |
| string storage (2.29 MB, aligned) | 3,296 |
| everything else | ~17,000 |

## Changes

- `runReactNativeBundleCommand` and `runExpoBundleCommand` pass `--minify false`, matching what the native build embeds. Expo has the same mismatch: its native build runs `expo export:embed` through the same React Native build scripts, which pass `--minify false` under Hermes.
- The flag is listed before the caller's `extraBundlerOptions` so an explicit `--minify` still wins.

## Verification

Recompiled the same commit two ways against the real base bundle taken from the binary, with `-base-bytecode` alignment in both runs:

| `--minify` | bundle | patch |
| --- | ---: | ---: |
| `true` (before) | 17,768,844 | 1,728,685 |
| `false` (after) | 18,039,428 | **137,773** |

The 1,728,685 reproduction lines up with the 1,727,034 patch the pipeline actually shipped, which confirms the setup reproduces the real build. `-O` turned out to make no difference — byte-identical output with and without it.

Cost of the change: the full bundle grows 270 KB (1.5%).

- `npm run --workspace cli test` — 7 suites / 70 tests pass
- `npm run type:cli` passes; eslint reports nothing on the changed files
