### PR TITLE
feat: build and publish per-base asset diff archives

### DIFF
--- a/cli/commands/releaseCommand/addToReleaseHistory.ts
+++ b/cli/commands/releaseCommand/addToReleaseHistory.ts
@@ -15,6 +15,7 @@ export async function addToReleaseHistory(
     mandatory: boolean,
     enable: boolean,
     rollout: number | undefined,
+    diffPackages: Record<string, string> | undefined,
 ): Promise<void> {
     const releaseHistory = await getReleaseHistory(binaryVersion, platform, identifier);
 
@@ -37,6 +38,12 @@ export async function addToReleaseHistory(
     // this history downloads the full bundle exactly as it did before patches existed.
     if (binaryPatchDownloadUrl) {
         newReleaseHistory[appVersion].binaryPatchDownloadUrl = binaryPatchDownloadUrl;
+    }
+
+    // Same for the asset diffs: an entry only names the bases it actually published a
+    // diff archive for.
+    if (diffPackages && Object.keys(diffPackages).length > 0) {
+        newReleaseHistory[appVersion].diffPackages = diffPackages;
     }
 
     if (typeof rollout === 'number') {

--- a/cli/commands/releaseCommand/index.test.ts
+++ b/cli/commands/releaseCommand/index.test.ts
@@ -12,6 +12,7 @@ jest.mock("./release.js");
 jest.mock("../../utils/fsUtils.js", () => ({
     findAndReadConfigFile: () => ({
         bundleUploader: async () => ({ downloadUrl: 'https://cdn.example.com/bundle' }),
+        bundleDownloader: async () => ({ downloadedFilePath: '/tmp/base.zip' }),
         getReleaseHistory: async () => ({}),
         setReleaseHistory: async () => undefined,
     }),
@@ -29,6 +30,8 @@ const ARG_INDEX = {
     bundleDirectory: 16,
     baseBundlePath: 19,
     onOversizedPatch: 20,
+    bundleDownloader: 21,
+    diffBaseCount: 22,
 } as const;
 
 /**
@@ -111,6 +114,35 @@ describe("release command options", () => {
     it("rejects an oversized patch policy it does not know", async () => {
         await expect(parseReleaseCommand(['-b', '1.0.0', '-v', '1.0.1', '--on-oversized-patch', 'ask']))
             .rejects.toThrow(/--on-oversized-patch.*'ask'.*skip, fail/s);
+
+        const { release } = await import("./release.js");
+        expect(jest.mocked(release)).not.toHaveBeenCalled();
+    });
+
+    it("hands the release the bundle downloader from the config and three diff bases by default", async () => {
+        const args = await runReleaseCommand(['-b', '1.0.0', '-v', '1.0.1']);
+
+        expect(typeof args[ARG_INDEX.bundleDownloader]).toBe('function');
+        expect(args[ARG_INDEX.diffBaseCount]).toBe(3);
+    });
+
+    it("passes the chosen asset diff base count through to the release", async () => {
+        const args = await runReleaseCommand(['-b', '1.0.0', '-v', '1.0.1', '--diff-base-count', '5']);
+
+        expect(args[ARG_INDEX.diffBaseCount]).toBe(5);
+    });
+
+    it.each([
+        ['is negative', '-1'],
+        ['is not a number at all', 'many'],
+    ])("rejects an asset diff base count that %s", async (_caseName, value) => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`process.exit(${code})`);
+        }) as never);
+
+        await expect(parseReleaseCommand(['-b', '1.0.0', '-v', '1.0.1', '--diff-base-count', value]))
+            .rejects.toThrow('process.exit(1)');
 
         const { release } = await import("./release.js");
         expect(jest.mocked(release)).not.toHaveBeenCalled();

--- a/cli/commands/releaseCommand/index.ts
+++ b/cli/commands/releaseCommand/index.ts
@@ -1,6 +1,6 @@
 import { program, Option } from "commander";
 import { findAndReadConfigFile } from "../../utils/fsUtils.js";
-import { release } from "./release.js";
+import { DEFAULT_DIFF_BASE_COUNT, release } from "./release.js";
 import {
     DEFAULT_OVERSIZED_PATCH_POLICY,
     OVERSIZED_PATCH_POLICIES,
@@ -30,6 +30,7 @@ type Options = {
     hashCalc?: boolean;
     binaryBundlePath?: string;
     onOversizedPatch: OversizedPatchPolicy;
+    diffBaseCount: number;
 }
 
 program.command('release')
@@ -55,11 +56,17 @@ program.command('release')
     .addOption(new Option('--on-oversized-patch <policy>', 'what to do when the binary patch bundle is not smaller than the full bundle: "skip" releases the full bundle only, "fail" stops the release before any upload')
         .choices(OVERSIZED_PATCH_POLICIES)
         .default(DEFAULT_OVERSIZED_PATCH_POLICY))
+    .option('--diff-base-count <number>', 'how many recent releases to build asset diff archives against (0 disables). Requires `bundleDownloader` in the config file.', parseDecimalInt, DEFAULT_DIFF_BASE_COUNT)
     .action(async (options: Options) => {
         const config = findAndReadConfigFile(process.cwd(), options.config);
 
         if (typeof options.rollout === 'number' && (options.rollout < 0 || options.rollout > 100)) {
             console.error('Rollout percentage number must be between 0 and 100 (inclusive).');
+            process.exit(1);
+        }
+
+        if (!Number.isInteger(options.diffBaseCount) || options.diffBaseCount < 0) {
+            console.error('--diff-base-count must be a whole number of releases, 0 or greater.');
             process.exit(1);
         }
 
@@ -93,10 +100,18 @@ program.command('release')
             options.hashCalc,
             baseBundlePath,
             options.onOversizedPatch,
+            config.bundleDownloader,
+            options.diffBaseCount,
         )
 
         console.log('🚀 Release completed.')
     });
+
+// Not `parseInt` itself: commander hands a coercion function the current value as its
+// second argument, which `parseInt` reads as the radix.
+function parseDecimalInt(value: string): number {
+    return parseInt(value, 10);
+}
 
 function parseBoolean(value: string): boolean | undefined {
     if (value === 'true') return true;

--- a/cli/commands/releaseCommand/release.test.ts
+++ b/cli/commands/releaseCommand/release.test.ts
@@ -1,9 +1,11 @@
+import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { release } from "./release.js";
 import { makeCodePushBundle } from "../../functions/makeCodePushBundle.js";
+import { ASSET_DIFF_ARCHIVE_INFIX, assetDiffArchiveName } from "../../functions/makeAssetDiffBundle.js";
 import {
     BINARY_PATCH_ARCHIVE_SUFFIX,
     BINARY_PATCH_BASE_RECORD_NAME,
@@ -15,7 +17,7 @@ import {
 import { applyPatch } from "../../utils/binaryPatch.js";
 import { generatePackageHashFromDirectory } from "../../utils/hash-utils.js";
 import { unzip } from "../../utils/unzip.js";
-import type { ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
+import type { CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
 
 /**
  * Covers the release flow around the binary patch option with `--skip-bundle`, which is
@@ -103,16 +105,17 @@ function recordingUploader(uploads: Uploads, failOn?: (filePath: string) => bool
     };
 }
 
-function historyStore() {
+function historyStore(existingHistory: ReleaseHistoryInterface = {}, onSave?: () => void) {
     const saved: ReleaseHistoryInterface[] = [];
     return {
         saved,
-        getReleaseHistory: async () => ({}) as ReleaseHistoryInterface,
+        getReleaseHistory: async () => existingHistory,
         setReleaseHistory: async (
             _binaryVersion: string,
             _jsonFilePath: string,
             releaseInfo: ReleaseHistoryInterface,
         ) => {
+            onSave?.();
             saved.push(releaseInfo);
         },
     };
@@ -127,11 +130,18 @@ type ReleaseOverrides = {
     onOversizedPatch?: OversizedPatchPolicy;
     /** Passed in when the case has to read the uploads of a release that threw. */
     uploads?: Uploads;
+    /** What the consumer already has released, which the asset diff bases are picked from. */
+    releaseHistory?: ReleaseHistoryInterface;
+    bundleDownloader?: CliConfigInterface['bundleDownloader'];
+    diffBaseCount?: number;
 };
 
 async function runRelease(staged: StagedBundle, overrides: ReleaseOverrides = {}) {
     const uploads: Uploads = overrides.uploads ?? [];
-    const history = historyStore();
+    const uploadCountsWhenHistorySaved: number[] = [];
+    const history = historyStore(overrides.releaseHistory, () => {
+        uploadCountsWhenHistorySaved.push(uploads.length);
+    });
 
     await release(
         recordingUploader(uploads, overrides.uploadFailsFor),
@@ -156,9 +166,11 @@ async function runRelease(staged: StagedBundle, overrides: ReleaseOverrides = {}
         undefined,
         overrides.binaryBundlePath,
         overrides.onOversizedPatch,
+        overrides.bundleDownloader,
+        overrides.diffBaseCount,
     );
 
-    return { uploads, releaseHistories: history.saved };
+    return { uploads, releaseHistories: history.saved, uploadCountsWhenHistorySaved };
 }
 
 let logs: string[];
@@ -578,5 +590,159 @@ describe("release --on-oversized-patch", () => {
         });
 
         expect(uploads).toHaveLength(2);
+    });
+});
+
+/**
+ * A release can also ship a diff per recently released package: the patch archive without
+ * the files that package already holds. The bases come out of the release history and are
+ * downloaded through the consumer's `bundleDownloader`, so a release only builds diffs
+ * where the consumer supplied one.
+ */
+describe("release with asset diff bases", () => {
+    /**
+     * The asset both packages hold. Sized like a real asset because a diff is only shipped
+     * when it comes out smaller than the patch archive it was derived from.
+     */
+    const sharedAsset = crypto.randomBytes(4096);
+
+    const PREVIOUS_APP_VERSION = '9.9.9';
+
+    function updateFiles(): Record<string, Buffer | string> {
+        return { 'main.jsbundle': fs.readFileSync(targetFixture), 'assets/keep.png': sharedAsset };
+    }
+
+    type StagedBaseRelease = { downloadUrl: string, packageHash: string, archivePath: string };
+
+    /** A package released earlier, as the history describes it and as the CDN serves it. */
+    async function stageBaseRelease(caseName: string): Promise<StagedBaseRelease> {
+        const caseDir = fs.mkdtempSync(path.join(workDir, `${caseName}-base-`));
+        const contentsPath = path.join(caseDir, CONTENTS_DIR_NAME);
+        const files: Record<string, Buffer | string> = {
+            'main.jsbundle': fs.readFileSync(baseFixture),
+            'assets/keep.png': sharedAsset,
+        };
+
+        for (const [relativePath, content] of Object.entries(files)) {
+            const filePath = path.join(contentsPath, relativePath);
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            fs.writeFileSync(filePath, content);
+        }
+
+        const archiveDir = path.join(caseDir, 'archive');
+        const { bundleFileName } = await makeCodePushBundle(contentsPath, archiveDir);
+
+        return {
+            downloadUrl: `https://cdn.example.com/released/${bundleFileName}`,
+            packageHash: bundleFileName,
+            archivePath: path.join(archiveDir, bundleFileName),
+        };
+    }
+
+    function releaseHistoryOf(base: StagedBaseRelease, versions = [PREVIOUS_APP_VERSION]): ReleaseHistoryInterface {
+        return Object.fromEntries(versions.map((version) => [
+            version,
+            {
+                enabled: true,
+                mandatory: false,
+                downloadUrl: base.downloadUrl,
+                packageHash: base.packageHash,
+            },
+        ]));
+    }
+
+    /** Serves the staged base archive, and records which releases were asked for. */
+    function recordingDownloader(base: StagedBaseRelease, downloads: string[]): CliConfigInterface['bundleDownloader'] {
+        return async (downloadUrl: string) => {
+            downloads.push(downloadUrl);
+            return { downloadedFilePath: base.archivePath };
+        };
+    }
+
+    it("publishes asset diff archives against recent releases and records them in the history", async () => {
+        const staged = await stageBundleOutput("asset-diff", updateFiles());
+        const base = await stageBaseRelease("asset-diff");
+        const downloads: string[] = [];
+
+        const { uploads, releaseHistories, uploadCountsWhenHistorySaved } = await runRelease(staged, {
+            binaryBundlePath: baseFixture,
+            releaseHistory: releaseHistoryOf(base),
+            bundleDownloader: recordingDownloader(base, downloads),
+        });
+
+        const diffFileName = `${staged.bundleFileName}${ASSET_DIFF_ARCHIVE_INFIX}${base.packageHash}.zip`;
+        // The diff is the last artifact: it is an optimisation on top of the patch, which
+        // is itself an optimisation on top of the full archive.
+        expect(uploads.map(({ filePath }) => path.basename(filePath))).toEqual([
+            staged.bundleFileName,
+            `${staged.bundleFileName}${BINARY_PATCH_ARCHIVE_SUFFIX}`,
+            diffFileName,
+        ]);
+        expect(downloads).toEqual([base.downloadUrl]);
+        // Every artifact is uploaded before the history points at any of them.
+        expect(uploadCountsWhenHistorySaved).toEqual([3]);
+        expect(releaseHistories[0][APP_VERSION].diffPackages).toEqual({
+            [base.packageHash]: uploads[2].downloadUrl,
+        });
+        expect(fs.existsSync(path.join(staged.bundleDirectory, diffFileName))).toBe(true);
+    });
+
+    it("publishes without diff archives when the config has no bundle downloader", async () => {
+        const staged = await stageBundleOutput("no-downloader", updateFiles());
+        const base = await stageBaseRelease("no-downloader");
+
+        const { uploads, releaseHistories } = await runRelease(staged, {
+            binaryBundlePath: baseFixture,
+            releaseHistory: releaseHistoryOf(base),
+        });
+
+        expect(uploads).toHaveLength(2);
+        // A release without diffs says nothing about them, so a client reading this history
+        // behaves exactly as it did before asset diffs existed.
+        expect(releaseHistories[0][APP_VERSION]).not.toHaveProperty('diffPackages');
+    });
+
+    it("publishes without diff archives when --diff-base-count is zero", async () => {
+        const staged = await stageBundleOutput("zero-bases", updateFiles());
+        const base = await stageBaseRelease("zero-bases");
+        const downloads: string[] = [];
+
+        const { uploads, releaseHistories } = await runRelease(staged, {
+            binaryBundlePath: baseFixture,
+            releaseHistory: releaseHistoryOf(base),
+            bundleDownloader: recordingDownloader(base, downloads),
+            diffBaseCount: 0,
+        });
+
+        expect(uploads).toHaveLength(2);
+        expect(downloads).toEqual([]);
+        expect(releaseHistories[0][APP_VERSION]).not.toHaveProperty('diffPackages');
+    });
+
+    it("builds one diff archive when two releases hold the same package", async () => {
+        const staged = await stageBundleOutput("repeated-base", updateFiles());
+        const base = await stageBaseRelease("repeated-base");
+        const downloads: string[] = [];
+
+        const { uploads, releaseHistories } = await runRelease(staged, {
+            binaryBundlePath: baseFixture,
+            releaseHistory: releaseHistoryOf(base, ['9.9.8', PREVIOUS_APP_VERSION]),
+            bundleDownloader: recordingDownloader(base, downloads),
+        });
+
+        expect(downloads).toHaveLength(2);
+        expect(uploads.filter(({ filePath }) => filePath.includes(ASSET_DIFF_ARCHIVE_INFIX))).toHaveLength(1);
+        expect(releaseHistories[0][APP_VERSION].diffPackages).toEqual({
+            [base.packageHash]: uploads[2].downloadUrl,
+        });
+    });
+
+    it("still picks the full bundle when diff archives sit in the output directory", async () => {
+        const staged = await stageBundleOutput("leftover-diff");
+        fs.writeFileSync(path.join(staged.bundleDirectory, assetDiffArchiveName('stale', 'stale-base')), 'stale');
+
+        const { uploads } = await runRelease(staged, { binaryBundlePath: baseFixture });
+
+        expect(path.basename(uploads[0].filePath)).toBe(staged.bundleFileName);
     });
 });

--- a/cli/commands/releaseCommand/release.test.ts
+++ b/cli/commands/releaseCommand/release.test.ts
@@ -614,13 +614,18 @@ describe("release with asset diff bases", () => {
 
     type StagedBaseRelease = { downloadUrl: string, packageHash: string, archivePath: string };
 
-    /** A package released earlier, as the history describes it and as the CDN serves it. */
-    async function stageBaseRelease(caseName: string): Promise<StagedBaseRelease> {
+    /**
+     * A package released earlier, as the history describes it and as the CDN serves it.
+     *
+     * @param ownAsset An asset only this release holds, which is what makes two staged base releases two packages rather than one.
+     */
+    async function stageBaseRelease(caseName: string, ownAsset?: string): Promise<StagedBaseRelease> {
         const caseDir = fs.mkdtempSync(path.join(workDir, `${caseName}-base-`));
         const contentsPath = path.join(caseDir, CONTENTS_DIR_NAME);
         const files: Record<string, Buffer | string> = {
             'main.jsbundle': fs.readFileSync(baseFixture),
             'assets/keep.png': sharedAsset,
+            ...(ownAsset === undefined ? {} : { 'assets/dropped.png': ownAsset }),
         };
 
         for (const [relativePath, content] of Object.entries(files)) {
@@ -651,10 +656,14 @@ describe("release with asset diff bases", () => {
         ]));
     }
 
-    /** Serves the staged base archive, and records which releases were asked for. */
-    function recordingDownloader(base: StagedBaseRelease, downloads: string[]): CliConfigInterface['bundleDownloader'] {
+    /** Serves the staged base archives, and records which releases were asked for. */
+    function recordingDownloader(bases: StagedBaseRelease[], downloads: string[]): CliConfigInterface['bundleDownloader'] {
         return async (downloadUrl: string) => {
             downloads.push(downloadUrl);
+            const base = bases.find((candidate) => candidate.downloadUrl === downloadUrl);
+            if (!base) {
+                throw new Error(`the downloader was called with an unexpected url: ${downloadUrl}`);
+            }
             return { downloadedFilePath: base.archivePath };
         };
     }
@@ -667,7 +676,7 @@ describe("release with asset diff bases", () => {
         const { uploads, releaseHistories, uploadCountsWhenHistorySaved } = await runRelease(staged, {
             binaryBundlePath: baseFixture,
             releaseHistory: releaseHistoryOf(base),
-            bundleDownloader: recordingDownloader(base, downloads),
+            bundleDownloader: recordingDownloader([base], downloads),
         });
 
         const diffFileName = `${staged.bundleFileName}${ASSET_DIFF_ARCHIVE_INFIX}${base.packageHash}.zip`;
@@ -710,7 +719,7 @@ describe("release with asset diff bases", () => {
         const { uploads, releaseHistories } = await runRelease(staged, {
             binaryBundlePath: baseFixture,
             releaseHistory: releaseHistoryOf(base),
-            bundleDownloader: recordingDownloader(base, downloads),
+            bundleDownloader: recordingDownloader([base], downloads),
             diffBaseCount: 0,
         });
 
@@ -727,7 +736,7 @@ describe("release with asset diff bases", () => {
         const { uploads, releaseHistories } = await runRelease(staged, {
             binaryBundlePath: baseFixture,
             releaseHistory: releaseHistoryOf(base, ['9.9.8', PREVIOUS_APP_VERSION]),
-            bundleDownloader: recordingDownloader(base, downloads),
+            bundleDownloader: recordingDownloader([base], downloads),
         });
 
         expect(downloads).toHaveLength(2);
@@ -735,6 +744,38 @@ describe("release with asset diff bases", () => {
         expect(releaseHistories[0][APP_VERSION].diffPackages).toEqual({
             [base.packageHash]: uploads[2].downloadUrl,
         });
+    });
+
+    it("releases the diffs that uploaded when one of them is rejected", async () => {
+        const staged = await stageBundleOutput("diff-upload-failure", updateFiles());
+        // Two packages to diff against, one of whose diffs the storage backend refuses.
+        const rejected = await stageBaseRelease("diff-upload-failure-rejected");
+        const kept = await stageBaseRelease("diff-upload-failure-kept", 'an asset of the older release');
+        const downloads: string[] = [];
+
+        const { uploads, releaseHistories } = await runRelease(staged, {
+            binaryBundlePath: baseFixture,
+            releaseHistory: {
+                ...releaseHistoryOf(kept, ['9.9.8']),
+                ...releaseHistoryOf(rejected, [PREVIOUS_APP_VERSION]),
+            },
+            bundleDownloader: recordingDownloader([kept, rejected], downloads),
+            uploadFailsFor: (filePath) => filePath.includes(rejected.packageHash),
+        });
+
+        expect(uploads.map(({ filePath }) => path.basename(filePath))).toEqual([
+            staged.bundleFileName,
+            `${staged.bundleFileName}${BINARY_PATCH_ARCHIVE_SUFFIX}`,
+            `${staged.bundleFileName}${ASSET_DIFF_ARCHIVE_INFIX}${kept.packageHash}.zip`,
+        ]);
+        // The release goes out with the two artifacts it needs, and describes only the diff
+        // a client can actually download.
+        expect(releaseHistories[0][APP_VERSION].diffPackages).toEqual({
+            [kept.packageHash]: uploads[2].downloadUrl,
+        });
+        expect(logs.filter((line) => line.startsWith('warn:')).join('\n')).toMatch(
+            new RegExp(`Skipping the asset diff archive against ${rejected.packageHash}`),
+        );
     });
 
     it("still picks the full bundle when diff archives sit in the output directory", async () => {

--- a/cli/commands/releaseCommand/release.ts
+++ b/cli/commands/releaseCommand/release.ts
@@ -110,9 +110,19 @@ export async function release(
     }
     const diffPackages: Record<string, string> = {};
     for (const { basePackageHash, filePath } of assetDiffArtifacts) {
-        const diffDownloadUrl = await uploadArtifact(bundleUploader, filePath, platform, identifier, 'asset diff bundle');
-        diffPackages[basePackageHash] = diffDownloadUrl;
-        console.log(`log: Asset diff archive against ${basePackageHash} uploaded (download url: ${diffDownloadUrl})`);
+        // A diff is an optimisation on top of the patch archive, which is uploaded by now:
+        // one that cannot be uploaded is left out of the history instead of failing the
+        // release the other two artifacts are ready for.
+        try {
+            const diffDownloadUrl = await uploadFile(bundleUploader, filePath, platform, identifier);
+            diffPackages[basePackageHash] = diffDownloadUrl;
+            console.log(`log: Asset diff archive against ${basePackageHash} uploaded (download url: ${diffDownloadUrl})`);
+        } catch (error) {
+            console.warn(
+                `warn: Skipping the asset diff archive against ${basePackageHash}: it could not be uploaded ` +
+                    `(${error instanceof Error ? error.message : String(error)}).`,
+            );
+        }
     }
 
     await addToReleaseHistory(
@@ -309,15 +319,22 @@ async function makeAssetDiffArtifacts({
         }
         builtAgainst.add(base.basePackageHash);
 
-        const assetDiff = await makeAssetDiffBundle({
-            patchBundleFilePath,
-            baseBundleFilePath: base.baseBundleFilePath,
-            bundleDirectory,
-            packageHash,
-            basePackageHash: base.basePackageHash,
-        });
-        if (assetDiff) {
-            artifacts.push({ basePackageHash: base.basePackageHash, filePath: assetDiff.diffBundleFilePath });
+        try {
+            const assetDiff = await makeAssetDiffBundle({
+                patchBundleFilePath,
+                baseBundleFilePath: base.baseBundleFilePath,
+                bundleDirectory,
+                packageHash,
+                basePackageHash: base.basePackageHash,
+            });
+            if (assetDiff) {
+                artifacts.push({ basePackageHash: base.basePackageHash, filePath: assetDiff.diffBundleFilePath });
+            }
+        } catch (error) {
+            console.warn(
+                `warn: Skipping the asset diff against ${base.basePackageHash}: it could not be built ` +
+                    `(${error instanceof Error ? error.message : String(error)}).`,
+            );
         }
     }
 
@@ -398,6 +415,7 @@ function warnOnBaseBundleMismatch(outputPath: string, baseBundlePath: string): v
     }
 }
 
+/** Uploads an artifact the release cannot go out without, so a failure ends the program. */
 async function uploadArtifact(
     bundleUploader: CliConfigInterface['bundleUploader'],
     filePath: string,
@@ -406,10 +424,19 @@ async function uploadArtifact(
     artifactName: string,
 ): Promise<string> {
     try {
-        const { downloadUrl } = await bundleUploader(filePath, platform, identifier);
-        return downloadUrl
+        return await uploadFile(bundleUploader, filePath, platform, identifier);
     } catch (error) {
         console.error(`Failed to upload the ${artifactName} file. Exiting the program.\n`, error)
         process.exit(1)
     }
+}
+
+async function uploadFile(
+    bundleUploader: CliConfigInterface['bundleUploader'],
+    filePath: string,
+    platform: 'ios' | 'android',
+    identifier: string | undefined,
+): Promise<string> {
+    const { downloadUrl } = await bundleUploader(filePath, platform, identifier);
+    return downloadUrl
 }

--- a/cli/commands/releaseCommand/release.ts
+++ b/cli/commands/releaseCommand/release.ts
@@ -2,9 +2,11 @@ import fs from "fs";
 import path from "path";
 import { bundleCodePush, resolveJsBundleName } from "../bundleCommand/bundleCodePush.js";
 import { addToReleaseHistory } from "./addToReleaseHistory.js";
-import type { CliConfigInterface } from "../../../typings/react-native-code-push.d.ts";
+import type { CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
 import { generatePackageHashFromDirectory } from "../../utils/hash-utils.js";
 import { unzip } from "../../utils/unzip.js";
+import { ASSET_DIFF_ARCHIVE_INFIX, makeAssetDiffBundle } from "../../functions/makeAssetDiffBundle.js";
+import { resolveAssetDiffBases } from "../../functions/resolveAssetDiffBases.js";
 import {
     BINARY_PATCH_ARCHIVE_SUFFIX,
     BINARY_PATCH_BASE_RECORD_NAME,
@@ -19,6 +21,9 @@ import {
     type BinaryPatchBundle,
     type OversizedPatchPolicy,
 } from "../../functions/makeBinaryPatchBundle.js";
+
+/** How many of the most recent releases a release builds asset diff archives against. */
+export const DEFAULT_DIFF_BASE_COUNT = 3;
 
 export async function release(
     bundleUploader: CliConfigInterface['bundleUploader'],
@@ -42,6 +47,8 @@ export async function release(
     hashCalc?: boolean,
     baseBundlePath?: string,
     onOversizedPatch: OversizedPatchPolicy = DEFAULT_OVERSIZED_PATCH_POLICY,
+    bundleDownloader?: CliConfigInterface['bundleDownloader'],
+    diffBaseCount: number = DEFAULT_DIFF_BASE_COUNT,
 ): Promise<void> {
     if (baseBundlePath) {
         // Checked before the bundler runs, so the wrong base bundle costs a second rather
@@ -77,6 +84,22 @@ export async function release(
         })
         : null;
 
+    // A diff is the patch archive with what a base package already holds taken out, so it
+    // only exists where a patch does - and only a consumer that can hand back a released
+    // archive can supply the bases to diff against.
+    const assetDiffArtifacts = binaryPatch && bundleDownloader && diffBaseCount > 0
+        ? await makeAssetDiffArtifacts({
+            patchBundleFilePath: binaryPatch.patchBundleFilePath,
+            releaseHistory: await getReleaseHistory(binaryVersion, platform, identifier),
+            diffBaseCount,
+            bundleDownloader,
+            bundleDirectory,
+            packageHash,
+            platform,
+            identifier,
+        })
+        : [];
+
     // Every artifact is uploaded before the release history is touched, so a failed
     // upload leaves the history describing only updates that can actually be downloaded.
     const downloadUrl = await uploadArtifact(bundleUploader, bundleFilePath, platform, identifier, 'bundle');
@@ -84,6 +107,12 @@ export async function release(
     if (binaryPatch) {
         patchDownloadUrl = await uploadArtifact(bundleUploader, binaryPatch.patchBundleFilePath, platform, identifier, 'binary patch bundle');
         console.log(`log: Binary patch archive uploaded (download url: ${patchDownloadUrl})`);
+    }
+    const diffPackages: Record<string, string> = {};
+    for (const { basePackageHash, filePath } of assetDiffArtifacts) {
+        const diffDownloadUrl = await uploadArtifact(bundleUploader, filePath, platform, identifier, 'asset diff bundle');
+        diffPackages[basePackageHash] = diffDownloadUrl;
+        console.log(`log: Asset diff archive against ${basePackageHash} uploaded (download url: ${diffDownloadUrl})`);
     }
 
     await addToReleaseHistory(
@@ -99,6 +128,7 @@ export async function release(
         mandatory,
         enable,
         rollout,
+        Object.keys(diffPackages).length > 0 ? diffPackages : undefined,
     )
 
     if (!skipCleanup) {
@@ -111,9 +141,11 @@ function cleanUpOutputs(dir: string) {
 }
 
 function readBundleFileNameFrom(bundleDirectory: string): string {
-    // A previous release of the same bundle may have left its patch archive here, and
-    // that archive is derived from the bundle file rather than a candidate for release.
-    const files = fs.readdirSync(bundleDirectory).filter((file) => !file.endsWith(BINARY_PATCH_ARCHIVE_SUFFIX));
+    // A previous release of the same bundle may have left its patch and diff archives
+    // here, and those are derived from the bundle file rather than candidates for release.
+    const files = fs.readdirSync(bundleDirectory).filter(
+        (file) => !file.endsWith(BINARY_PATCH_ARCHIVE_SUFFIX) && !file.includes(ASSET_DIFF_ARCHIVE_INFIX),
+    );
     if (files.length !== 1) {
         console.error('The bundlePath must contain only one file.');
         process.exit(1);
@@ -227,6 +259,69 @@ async function makeBinaryPatchArtifact({
             fs.rmSync(extractDir, { recursive: true, force: true });
         }
     }
+}
+
+type AssetDiffArtifact = { basePackageHash: string, filePath: string };
+
+/**
+ * Builds a diff artifact per recently released package, for the clients holding one.
+ *
+ * A base that cannot be downloaded or verified is left out by the resolver, and a diff
+ * that comes out no smaller than the patch archive is not published. Either way the
+ * release goes out with its full and patch archives, serving fewer diffs.
+ *
+ * @return {Promise<AssetDiffArtifact[]>} The diff archives to upload, each naming the package it was built against.
+ */
+async function makeAssetDiffArtifacts({
+    patchBundleFilePath,
+    releaseHistory,
+    diffBaseCount,
+    bundleDownloader,
+    bundleDirectory,
+    packageHash,
+    platform,
+    identifier,
+}: {
+    patchBundleFilePath: string;
+    releaseHistory: ReleaseHistoryInterface;
+    diffBaseCount: number;
+    bundleDownloader: NonNullable<CliConfigInterface['bundleDownloader']>;
+    bundleDirectory: string;
+    packageHash: string;
+    platform: 'ios' | 'android';
+    identifier: string | undefined;
+}): Promise<AssetDiffArtifact[]> {
+    const bases = await resolveAssetDiffBases({
+        releaseHistory,
+        diffBaseCount,
+        bundleDownloader,
+        platform,
+        identifier,
+    });
+
+    const artifacts: AssetDiffArtifact[] = [];
+    const builtAgainst = new Set<string>();
+    for (const base of bases) {
+        // Releasing identical contents twice leaves two history entries describing one
+        // package, and their diff is the same archive built - and named - twice.
+        if (builtAgainst.has(base.basePackageHash)) {
+            continue;
+        }
+        builtAgainst.add(base.basePackageHash);
+
+        const assetDiff = await makeAssetDiffBundle({
+            patchBundleFilePath,
+            baseBundleFilePath: base.baseBundleFilePath,
+            bundleDirectory,
+            packageHash,
+            basePackageHash: base.basePackageHash,
+        });
+        if (assetDiff) {
+            artifacts.push({ basePackageHash: base.basePackageHash, filePath: assetDiff.diffBundleFilePath });
+        }
+    }
+
+    return artifacts;
 }
 
 /**

--- a/cli/functions/makeAssetDiffBundle.test.ts
+++ b/cli/functions/makeAssetDiffBundle.test.ts
@@ -1,0 +1,283 @@
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import {
+    ASSET_DIFF_ARCHIVE_INFIX,
+    ASSET_DIFF_MANIFEST_NAME,
+    assetDiffArchiveName,
+    makeAssetDiffBundle,
+} from "./makeAssetDiffBundle.js";
+import { BINARY_PATCH_MANIFEST_NAME, makeBinaryPatchBundle } from "./makeBinaryPatchBundle.js";
+import { makeCodePushBundle } from "./makeCodePushBundle.js";
+import { applyPatch } from "../utils/binaryPatch.js";
+import { generatePackageHashFromDirectory } from "../utils/hash-utils.js";
+import { walk } from "../utils/promisfied-fs.js";
+import { unzip } from "../utils/unzip.js";
+
+/**
+ * Exercises the diff artifact against real archives, real hdiffz output and real hashes.
+ * A diff is only worth shipping if a client that owns the base package can rebuild the
+ * exact contents of the new full archive from it, and only real bytes prove that.
+ */
+
+/** The directory a CodePush archive keeps its contents in, for legacy reasons. */
+const CONTENTS_DIR_NAME = 'CodePush';
+
+const BUNDLE_NAME = 'index.android.bundle';
+
+function findRepoRoot(): string {
+    let dir = process.cwd();
+    for (;;) {
+        if (fs.existsSync(path.join(dir, "scripts", "binary-patch", "build-hdiffpatch.sh"))) {
+            return dir;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            throw new Error(`cannot locate the repository root from ${process.cwd()}`);
+        }
+        dir = parent;
+    }
+}
+
+const repoRoot = findRepoRoot();
+const fixtureDir = path.join(repoRoot, "cli", "fixtures", "binary-patch");
+const baseFixture = path.join(fixtureDir, "base.bundle");
+const targetFixture = path.join(fixtureDir, "target.bundle");
+
+/**
+ * The asset both releases hold. Sized like a real asset rather than a few bytes, because
+ * the builder only ships a diff that is smaller than the patch archive: dropping a
+ * four-byte file would save less than the deletion manifest costs, and the builder would
+ * rightly report the diff as not worth shipping.
+ */
+const unchangedAsset = crypto.randomBytes(4096);
+
+let workDir: string;
+
+/** A unique directory per test so a failed run never leaks state into the next one. */
+function makeCaseDir(name: string): string {
+    return fs.mkdtempSync(path.join(workDir, `${name}-`));
+}
+
+/** Writes an update contents directory shaped like the one the bundler produces. */
+function writeUpdateContents(parentDir: string, files: Record<string, Buffer | string>): string {
+    const contentsPath = path.join(parentDir, CONTENTS_DIR_NAME);
+    for (const [relativePath, content] of Object.entries(files)) {
+        const filePath = path.join(contentsPath, relativePath);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, content);
+    }
+    return contentsPath;
+}
+
+function baseContentFiles(): Record<string, Buffer | string> {
+    return {
+        [BUNDLE_NAME]: fs.readFileSync(baseFixture),
+        'assets/keep.png': unchangedAsset,
+        'assets/change.png': 'OLD',
+        'assets/gone.png': 'GONE',
+    };
+}
+
+function updateContentFiles(): Record<string, Buffer | string> {
+    return {
+        [BUNDLE_NAME]: fs.readFileSync(targetFixture),
+        'assets/keep.png': unchangedAsset,
+        'assets/change.png': 'NEW',
+        'assets/new.png': 'ADDED',
+    };
+}
+
+type Release = {
+    caseDir: string;
+    bundleDirectory: string;
+    packageHash: string;
+    basePackageHash: string;
+    baseBundleFilePath: string;
+    patchBundleFilePath: string;
+};
+
+/**
+ * Releases a base package and then the update, exactly the way the CLI does: a full
+ * archive for each, plus the patch archive the diff is derived from.
+ */
+async function stageRelease(name: string, baseFiles: Record<string, Buffer | string>): Promise<Release> {
+    const caseDir = makeCaseDir(name);
+    const bundleDirectory = path.join(caseDir, 'bundleOutput');
+
+    const baseContents = writeUpdateContents(path.join(caseDir, 'base'), baseFiles);
+    const { bundleFileName: basePackageHash } = await makeCodePushBundle(baseContents, bundleDirectory);
+
+    const updateContents = writeUpdateContents(path.join(caseDir, 'update'), updateContentFiles());
+    const { bundleFileName: packageHash } = await makeCodePushBundle(updateContents, bundleDirectory);
+
+    const { patchBundleFilePath } = await makeBinaryPatchBundle({
+        contentsPath: updateContents,
+        baseBundlePath: baseFixture,
+        bundleRelativePath: BUNDLE_NAME,
+        bundleDirectory,
+        packageHash,
+    });
+
+    return {
+        caseDir,
+        bundleDirectory,
+        packageHash,
+        basePackageHash,
+        baseBundleFilePath: path.join(bundleDirectory, basePackageHash),
+        patchBundleFilePath,
+    };
+}
+
+async function extractTo(archivePath: string, destination: string): Promise<string> {
+    fs.mkdirSync(destination, { recursive: true });
+    await unzip(archivePath, destination);
+    return destination;
+}
+
+/** Every file in an archive, as the archive names it. */
+async function listArchiveFiles(archivePath: string, destination: string): Promise<string[]> {
+    await extractTo(archivePath, destination);
+    const files = await walk(destination);
+    return files.map((filePath) => path.relative(destination, filePath).split(path.sep).join('/')).sort();
+}
+
+beforeAll(() => {
+    // hdiffz/hpatchz are provisioned for the whole run by the jest global setup.
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "codepush-asset-diff-"));
+});
+
+afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("makeAssetDiffBundle", () => {
+    it("ships only the files the base does not already hold", async () => {
+        const release = await stageRelease("ships", baseContentFiles());
+
+        const diff = await makeAssetDiffBundle({
+            patchBundleFilePath: release.patchBundleFilePath,
+            baseBundleFilePath: release.baseBundleFilePath,
+            bundleDirectory: release.bundleDirectory,
+            packageHash: release.packageHash,
+            basePackageHash: release.basePackageHash,
+        });
+
+        expect(diff).not.toBeNull();
+        expect(path.basename(diff!.diffBundleFilePath)).toBe(
+            `${release.packageHash}${ASSET_DIFF_ARCHIVE_INFIX}${release.basePackageHash}.zip`,
+        );
+        expect(await listArchiveFiles(diff!.diffBundleFilePath, path.join(release.caseDir, "extracted"))).toEqual(
+            [
+                ASSET_DIFF_MANIFEST_NAME,
+                `${CONTENTS_DIR_NAME}/${BINARY_PATCH_MANIFEST_NAME}`,
+                `${CONTENTS_DIR_NAME}/${BUNDLE_NAME}.patch`,
+                `${CONTENTS_DIR_NAME}/assets/change.png`,
+                `${CONTENTS_DIR_NAME}/assets/new.png`,
+            ].sort(),
+        );
+    });
+
+    it("lists files the base holds but the update dropped, with the contents prefix", async () => {
+        const release = await stageRelease("deletions", baseContentFiles());
+
+        const diff = await makeAssetDiffBundle({
+            patchBundleFilePath: release.patchBundleFilePath,
+            baseBundleFilePath: release.baseBundleFilePath,
+            bundleDirectory: release.bundleDirectory,
+            packageHash: release.packageHash,
+            basePackageHash: release.basePackageHash,
+        });
+
+        const extracted = await extractTo(diff!.diffBundleFilePath, path.join(release.caseDir, "extracted"));
+        const manifest = JSON.parse(fs.readFileSync(path.join(extracted, ASSET_DIFF_MANIFEST_NAME), 'utf8'));
+
+        expect(manifest.deletedFiles).toEqual([`${CONTENTS_DIR_NAME}/assets/gone.png`]);
+    });
+
+    it("reproduces the full package hash when merged the way the client merges", async () => {
+        const release = await stageRelease("round-trip", baseContentFiles());
+
+        const diff = await makeAssetDiffBundle({
+            patchBundleFilePath: release.patchBundleFilePath,
+            baseBundleFilePath: release.baseBundleFilePath,
+            bundleDirectory: release.bundleDirectory,
+            packageHash: release.packageHash,
+            basePackageHash: release.basePackageHash,
+        });
+
+        // The installed base package, which is what a client merges the diff onto.
+        const packageDir = await extractTo(release.baseBundleFilePath, path.join(release.caseDir, "package"));
+        const diffDir = await extractTo(diff!.diffBundleFilePath, path.join(release.caseDir, "downloaded"));
+        const diffContents = path.join(diffDir, CONTENTS_DIR_NAME);
+
+        // Rebuild the bundle from its patch, then drop the two patch-only files.
+        const patchManifest = JSON.parse(fs.readFileSync(path.join(diffContents, BINARY_PATCH_MANIFEST_NAME), 'utf8'));
+        applyPatch(
+            baseFixture,
+            path.join(diffContents, patchManifest.patchFile),
+            path.join(diffContents, patchManifest.bundlePath),
+        );
+        fs.rmSync(path.join(diffContents, patchManifest.patchFile));
+        fs.rmSync(path.join(diffContents, BINARY_PATCH_MANIFEST_NAME));
+
+        // Apply the deletions to the base package, then drop the deletion manifest.
+        const diffManifestPath = path.join(diffDir, ASSET_DIFF_MANIFEST_NAME);
+        const { deletedFiles } = JSON.parse(fs.readFileSync(diffManifestPath, 'utf8'));
+        for (const deletedFile of deletedFiles) {
+            fs.rmSync(path.join(packageDir, deletedFile));
+        }
+        fs.rmSync(diffManifestPath);
+
+        // Overlay what the diff shipped onto the base package.
+        fs.cpSync(diffDir, packageDir, { recursive: true });
+
+        expect(await generatePackageHashFromDirectory(path.join(packageDir, CONTENTS_DIR_NAME), packageDir)).toBe(
+            release.packageHash,
+        );
+    });
+
+    it("skips the diff when it would not be smaller than the patch archive", async () => {
+        // A base that shares no bytes with the update leaves nothing to prune, so the diff
+        // is the patch archive plus a deletion manifest.
+        const release = await stageRelease("oversized", {
+            [BUNDLE_NAME]: fs.readFileSync(baseFixture),
+            'assets/keep.png': crypto.randomBytes(4096),
+            'assets/change.png': 'OLD',
+        });
+        const archivesBefore = fs.readdirSync(release.bundleDirectory).sort();
+
+        const diff = await makeAssetDiffBundle({
+            patchBundleFilePath: release.patchBundleFilePath,
+            baseBundleFilePath: release.baseBundleFilePath,
+            bundleDirectory: release.bundleDirectory,
+            packageHash: release.packageHash,
+            basePackageHash: release.basePackageHash,
+        });
+
+        expect(diff).toBeNull();
+        expect(
+            fs.existsSync(
+                path.join(release.bundleDirectory, assetDiffArchiveName(release.packageHash, release.basePackageHash)),
+            ),
+        ).toBe(false);
+        expect(fs.readdirSync(release.bundleDirectory).sort()).toEqual(archivesBefore);
+    });
+
+    it("leaves no working directory behind", async () => {
+        const release = await stageRelease("cleanup", baseContentFiles());
+        const entriesBefore = fs.readdirSync(release.caseDir).sort();
+
+        await makeAssetDiffBundle({
+            patchBundleFilePath: release.patchBundleFilePath,
+            baseBundleFilePath: release.baseBundleFilePath,
+            bundleDirectory: release.bundleDirectory,
+            packageHash: release.packageHash,
+            basePackageHash: release.basePackageHash,
+        });
+
+        expect(fs.readdirSync(release.caseDir).sort()).toEqual(entriesBefore);
+    });
+});

--- a/cli/functions/makeAssetDiffBundle.ts
+++ b/cli/functions/makeAssetDiffBundle.ts
@@ -156,7 +156,10 @@ async function listFilesRelative(directoryPath: string): Promise<string[]> {
 }
 
 function sameBytes(left: string, right: string): boolean {
-    if (fs.statSync(left).size !== fs.statSync(right).size) {
+    // A base that holds a directory where the update holds a file has nothing the update
+    // can be spared from downloading, so the file ships.
+    const rightStats = fs.statSync(right);
+    if (!rightStats.isFile() || fs.statSync(left).size !== rightStats.size) {
         return false;
     }
     return fs.readFileSync(left).equals(fs.readFileSync(right));

--- a/cli/functions/makeAssetDiffBundle.ts
+++ b/cli/functions/makeAssetDiffBundle.ts
@@ -1,0 +1,163 @@
+/**
+ * Builds the diff artifact a client can install on top of one particular base package.
+ *
+ * A diff archive is the patch archive of this release with every file the base package
+ * already holds byte for byte taken out, plus a manifest naming the files the base holds
+ * that the update dropped. A client copies its installed base package, applies the
+ * deletions, rebuilds the JS bundle from the patch and overlays what the diff shipped -
+ * which leaves it holding exactly the contents of the full archive, and therefore the
+ * same `packageHash`. One release can serve a diff per base it was built against.
+ *
+ * The diff is derived from the artifacts the release already produced rather than from
+ * the bundler, so it costs no extra bundling and cannot drift from what was published.
+ */
+
+import fs from "fs";
+import path from "path";
+import shell from "shelljs";
+import { normalizePath } from "../utils/file-utils.js";
+import { walk } from "../utils/promisfied-fs.js";
+import { zipDirectoryContents } from "../utils/zip.js";
+import {
+    BINARY_PATCH_MANIFEST_NAME,
+    type BinaryPatchManifest,
+    extractCodePushBundleContents,
+} from "./makeBinaryPatchBundle.js";
+
+/**
+ * Manifest listing what a client must delete from its copy of the base package. It sits
+ * at the archive root, outside the contents directory, because that is where the native
+ * clients look for it - and because a file inside the contents would change the package
+ * hash the merged folder has to reproduce.
+ */
+export const ASSET_DIFF_MANIFEST_NAME = 'hotcodepush.json';
+
+/** Separates the two hashes, so a diff archive names both the update and the base it needs. */
+export const ASSET_DIFF_ARCHIVE_INFIX = '-diff-';
+
+const TEMP_ASSET_DIFF_DIR_NAME = 'temp_contents_for_asset_diff';
+
+export type AssetDiffManifest = {
+    /** Paths relative to the package folder root, so with the contents directory prefix. */
+    deletedFiles: string[];
+};
+
+export function assetDiffArchiveName(packageHash: string, basePackageHash: string): string {
+    return `${packageHash}${ASSET_DIFF_ARCHIVE_INFIX}${basePackageHash}.zip`;
+}
+
+/**
+ * Creates the diff archive for a release against one base package.
+ *
+ * @param patchBundleFilePath {string} Patch archive this release already built
+ * @param baseBundleFilePath {string} Full archive of the base release, downloaded locally
+ * @param bundleDirectory {string} Directory the release artifacts are written to
+ * @param packageHash {string} Package hash of this release
+ * @param basePackageHash {string} Package hash of the base release
+ * @return The diff archive, or `null` when it is not smaller than the patch archive it
+ * was derived from, in which case there is nothing to gain from publishing it.
+ */
+export async function makeAssetDiffBundle({
+    patchBundleFilePath,
+    baseBundleFilePath,
+    bundleDirectory,
+    packageHash,
+    basePackageHash,
+}: {
+    patchBundleFilePath: string;
+    baseBundleFilePath: string;
+    bundleDirectory: string;
+    packageHash: string;
+    basePackageHash: string;
+}): Promise<{ diffBundleFilePath: string } | null> {
+    // Kept next to the release output rather than in the system temp directory so a crash
+    // leaves the leftovers where the rest of the build output is cleaned up. Named after
+    // the base so building the diffs of one release against several bases at once cannot
+    // have two of them share a working directory.
+    const tempRoot = path.join(
+        path.dirname(path.resolve(bundleDirectory)),
+        `${TEMP_ASSET_DIFF_DIR_NAME}_${basePackageHash}`,
+    );
+    const stagingRoot = path.join(tempRoot, 'archive');
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+
+    try {
+        // Extracted into separate parents: `extractCodePushBundleContents` reuses one
+        // directory name, so a shared parent would have the second unpack wipe the first.
+        const { contentsPath: patchContents } = await extractCodePushBundleContents(
+            patchBundleFilePath,
+            path.join(tempRoot, 'patch-archive'),
+        );
+        const { contentsPath: baseContents } = await extractCodePushBundleContents(
+            baseBundleFilePath,
+            path.join(tempRoot, 'base-archive'),
+        );
+
+        const patchManifest: BinaryPatchManifest = JSON.parse(
+            fs.readFileSync(path.join(patchContents, BINARY_PATCH_MANIFEST_NAME), 'utf8'),
+        );
+        // Manifest paths are compared against archive-relative paths, which are POSIX.
+        const patchFile = normalizePath(patchManifest.patchFile);
+        const bundlePath = normalizePath(patchManifest.bundlePath);
+
+        // What the full archive of this release holds: the patch archive without its two
+        // patch-only files, plus the bundle the patch rebuilds. Deletions are worked out
+        // against that set, not against the subset the diff happens to ship.
+        const patchFiles = await listFilesRelative(patchContents);
+        const updateFiles = new Set(
+            patchFiles.filter(
+                (relativePath) => relativePath !== BINARY_PATCH_MANIFEST_NAME && relativePath !== patchFile,
+            ),
+        );
+        updateFiles.add(bundlePath);
+
+        // The archive root directory name is part of the contents layout, so the diff
+        // archive has to reuse the name the full archive used.
+        const contentsDirName = path.basename(patchContents);
+        const stagedContents = path.join(stagingRoot, contentsDirName);
+        fs.cpSync(patchContents, stagedContents, { recursive: true });
+        for (const relativePath of patchFiles) {
+            const baseFile = path.join(baseContents, relativePath);
+            if (fs.existsSync(baseFile) && sameBytes(path.join(patchContents, relativePath), baseFile)) {
+                fs.rmSync(path.join(stagedContents, relativePath));
+            }
+        }
+
+        const manifest: AssetDiffManifest = {
+            deletedFiles: (await listFilesRelative(baseContents))
+                .filter((relativePath) => !updateFiles.has(relativePath))
+                .map((relativePath) => `${contentsDirName}/${relativePath}`),
+        };
+        fs.writeFileSync(path.join(stagingRoot, ASSET_DIFF_MANIFEST_NAME), JSON.stringify(manifest, null, 2));
+
+        const diffArchiveZipPath = await zipDirectoryContents(stagingRoot);
+        if (fs.statSync(diffArchiveZipPath).size >= fs.statSync(patchBundleFilePath).size) {
+            // A diff that costs a client as much as the patch archive is never the better
+            // artifact of the two, and the release still publishes that patch archive.
+            fs.rmSync(diffArchiveZipPath);
+            return null;
+        }
+
+        const diffBundleFilePath = path.join(bundleDirectory, assetDiffArchiveName(packageHash, basePackageHash));
+        shell.mkdir('-p', bundleDirectory);
+        shell.mv(diffArchiveZipPath, diffBundleFilePath);
+
+        return { diffBundleFilePath };
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}
+
+/** Every file below `directoryPath`, as POSIX paths relative to it. */
+async function listFilesRelative(directoryPath: string): Promise<string[]> {
+    const files = await walk(directoryPath);
+    return files.map((filePath) => normalizePath(path.relative(directoryPath, filePath)));
+}
+
+function sameBytes(left: string, right: string): boolean {
+    if (fs.statSync(left).size !== fs.statSync(right).size) {
+        return false;
+    }
+    return fs.readFileSync(left).equals(fs.readFileSync(right));
+}

--- a/cli/functions/resolveAssetDiffBases.test.ts
+++ b/cli/functions/resolveAssetDiffBases.test.ts
@@ -153,6 +153,31 @@ describe("resolveAssetDiffBases", () => {
         expect(calls).toEqual([[released.downloadUrl, 'ios', undefined]]);
     });
 
+    it("ignores a history entry whose key is not a version, and resolves the rest", async () => {
+        const [released] = await stageReleases(['1.4.0']);
+        const { download, calls } = fakeDownloader({ [released.downloadUrl]: released.archivePath });
+
+        const bases = await resolveAssetDiffBases({
+            releaseHistory: {
+                ...releaseHistoryOf([released]),
+                'not-a-version': {
+                    enabled: true,
+                    mandatory: false,
+                    downloadUrl: released.downloadUrl,
+                    packageHash: released.packageHash,
+                },
+            },
+            diffBaseCount: 2,
+            bundleDownloader: download,
+            platform: 'ios',
+        });
+
+        expect(bases).toEqual([
+            { basePackageHash: released.packageHash, baseBundleFilePath: released.archivePath },
+        ]);
+        expect(calls).toEqual([[released.downloadUrl, 'ios', undefined]]);
+    });
+
     it("drops a base whose downloaded bytes do not match its recorded package hash", async () => {
         const [older, newer] = await stageReleases(['1.2.0', '1.2.1']);
         // The newest base comes back as some other release's archive.

--- a/cli/functions/resolveAssetDiffBases.test.ts
+++ b/cli/functions/resolveAssetDiffBases.test.ts
@@ -1,0 +1,195 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+import { makeCodePushBundle } from "./makeCodePushBundle.js";
+import { resolveAssetDiffBases } from "./resolveAssetDiffBases.js";
+import type { CliConfigInterface, ReleaseHistoryInterface } from "../../typings/react-native-code-push.d.ts";
+
+/**
+ * Exercises base acquisition against real archives and real hashes: a base is only usable
+ * if the bytes that came back are the ones the release history recorded, and only real
+ * archives prove that the verification accepts a good download and rejects a wrong one.
+ */
+
+/** The directory a CodePush archive keeps its contents in, for legacy reasons. */
+const CONTENTS_DIR_NAME = 'CodePush';
+
+/** Where the resolver unpacks a base for verification, so leftovers are recognizable. */
+const TEMP_DIR_PREFIX = 'codepush-asset-diff-base-';
+
+type StagedRelease = {
+    version: string;
+    downloadUrl: string;
+    packageHash: string;
+    archivePath: string;
+};
+
+let workDir: string;
+let bundleDirectory: string;
+
+/** Releases one full archive the way the CLI does, and returns what the history records. */
+async function stageRelease(version: string): Promise<StagedRelease> {
+    const contentsPath = path.join(workDir, version, CONTENTS_DIR_NAME);
+    fs.mkdirSync(contentsPath, { recursive: true });
+    fs.writeFileSync(path.join(contentsPath, 'index.android.bundle'), `bundle bytes of ${version}`);
+
+    const { bundleFileName } = await makeCodePushBundle(contentsPath, bundleDirectory);
+
+    return {
+        version,
+        downloadUrl: `https://downloads.test/${version}.zip`,
+        packageHash: bundleFileName,
+        archivePath: path.join(bundleDirectory, bundleFileName),
+    };
+}
+
+async function stageReleases(versions: string[]): Promise<StagedRelease[]> {
+    const releases: StagedRelease[] = [];
+    for (const version of versions) {
+        releases.push(await stageRelease(version));
+    }
+    return releases;
+}
+
+function releaseHistoryOf(releases: StagedRelease[]): ReleaseHistoryInterface {
+    return Object.fromEntries(
+        releases.map((release) => [
+            release.version,
+            {
+                enabled: true,
+                mandatory: false,
+                downloadUrl: release.downloadUrl,
+                packageHash: release.packageHash,
+            },
+        ]),
+    );
+}
+
+/** Stands in for the consumer's downloader: hands back a local archive per download url. */
+function fakeDownloader(archives: Record<string, string | Error>) {
+    const calls: Array<[string, string, string | undefined]> = [];
+    const download: NonNullable<CliConfigInterface['bundleDownloader']> = async (
+        downloadUrl,
+        platform,
+        identifier,
+    ) => {
+        calls.push([downloadUrl, platform, identifier]);
+
+        const archive = archives[downloadUrl];
+        if (archive instanceof Error) {
+            throw archive;
+        }
+        if (!archive) {
+            throw new Error(`the downloader was called with an unexpected url: ${downloadUrl}`);
+        }
+        return { downloadedFilePath: archive };
+    };
+    return { download, calls };
+}
+
+function leftoverTempDirs(): string[] {
+    return fs.readdirSync(os.tmpdir()).filter((entry) => entry.startsWith(TEMP_DIR_PREFIX));
+}
+
+beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "codepush-base-resolution-"));
+    bundleDirectory = path.join(workDir, 'bundleOutput');
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("resolveAssetDiffBases", () => {
+    it("takes the newest releases first, up to the requested count", async () => {
+        const releases = await stageReleases(['1.0.0', '1.0.1', '1.0.2', '1.0.9', '1.0.10']);
+        const [newest, second] = [releases[4], releases[3]];
+        const { download, calls } = fakeDownloader(
+            Object.fromEntries(releases.map((release) => [release.downloadUrl, release.archivePath])),
+        );
+
+        const bases = await resolveAssetDiffBases({
+            releaseHistory: releaseHistoryOf(releases),
+            diffBaseCount: 2,
+            bundleDownloader: download,
+            platform: 'android',
+            identifier: 'my-app',
+        });
+
+        expect(bases).toEqual([
+            { basePackageHash: newest.packageHash, baseBundleFilePath: newest.archivePath },
+            { basePackageHash: second.packageHash, baseBundleFilePath: second.archivePath },
+        ]);
+        expect(calls).toEqual([
+            [newest.downloadUrl, 'android', 'my-app'],
+            [second.downloadUrl, 'android', 'my-app'],
+        ]);
+    });
+
+    it("skips history entries that lack a download url or a package hash", async () => {
+        const [released] = await stageReleases(['1.1.0']);
+        const { download, calls } = fakeDownloader({ [released.downloadUrl]: released.archivePath });
+
+        const bases = await resolveAssetDiffBases({
+            releaseHistory: {
+                ...releaseHistoryOf([released]),
+                // What `create-history` seeds for the update inside the app binary.
+                '1.1.1': { enabled: true, mandatory: false, downloadUrl: "", packageHash: "" },
+                '1.1.2': { enabled: true, mandatory: false, downloadUrl: released.downloadUrl, packageHash: "" },
+            },
+            diffBaseCount: 1,
+            bundleDownloader: download,
+            platform: 'ios',
+        });
+
+        expect(bases).toEqual([
+            { basePackageHash: released.packageHash, baseBundleFilePath: released.archivePath },
+        ]);
+        expect(calls).toEqual([[released.downloadUrl, 'ios', undefined]]);
+    });
+
+    it("drops a base whose downloaded bytes do not match its recorded package hash", async () => {
+        const [older, newer] = await stageReleases(['1.2.0', '1.2.1']);
+        // The newest base comes back as some other release's archive.
+        const { download } = fakeDownloader({
+            [newer.downloadUrl]: older.archivePath,
+            [older.downloadUrl]: older.archivePath,
+        });
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const bases = await resolveAssetDiffBases({
+            releaseHistory: releaseHistoryOf([older, newer]),
+            diffBaseCount: 2,
+            bundleDownloader: download,
+            platform: 'android',
+        });
+
+        expect(bases).toEqual([{ basePackageHash: older.packageHash, baseBundleFilePath: older.archivePath }]);
+        expect(warn.mock.calls.join('\n')).toMatch(/1\.2\.1/);
+        expect(leftoverTempDirs()).toEqual([]);
+    });
+
+    it("drops a base whose download fails instead of failing the release", async () => {
+        const [older, newer] = await stageReleases(['1.3.0', '1.3.1']);
+        const { download } = fakeDownloader({
+            [newer.downloadUrl]: new Error('the network is down'),
+            [older.downloadUrl]: older.archivePath,
+        });
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const bases = await resolveAssetDiffBases({
+            releaseHistory: releaseHistoryOf([older, newer]),
+            diffBaseCount: 2,
+            bundleDownloader: download,
+            platform: 'android',
+        });
+
+        expect(bases).toEqual([{ basePackageHash: older.packageHash, baseBundleFilePath: older.archivePath }]);
+        expect(warn.mock.calls.join('\n')).toMatch(/1\.3\.1.*the network is down/s);
+    });
+});

--- a/cli/functions/resolveAssetDiffBases.ts
+++ b/cli/functions/resolveAssetDiffBases.ts
@@ -1,0 +1,98 @@
+/**
+ * Picks the previously released packages a new release builds asset diffs against, and
+ * hands back a verified local copy of each.
+ *
+ * A diff is only installable by a client whose package is byte for byte the base it was
+ * built against, so the base has to be the exact archive the release history describes.
+ * Every download is therefore unpacked and hashed before it is accepted: a base that is
+ * not what the history recorded would produce a diff that sends every client holding
+ * that version into the full-download fallback.
+ *
+ * Bases are the most recent releases, because that is where the installed clients are.
+ * One base failing is never a reason to fail the release - the release still publishes
+ * its full and patch archives, and simply serves fewer diffs.
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import semver from "semver";
+import { generatePackageHashFromDirectory } from "../utils/hash-utils.js";
+import { extractCodePushBundleContents } from "./makeBinaryPatchBundle.js";
+import type { CliConfigInterface, ReleaseHistoryInterface } from "../../typings/react-native-code-push.d.ts";
+
+const TEMP_DIR_PREFIX = 'codepush-asset-diff-base-';
+
+export type AssetDiffBase = {
+    basePackageHash: string;
+    baseBundleFilePath: string;
+};
+
+/**
+ * @param releaseHistory {ReleaseHistoryInterface} History of the binary version being released to
+ * @param diffBaseCount {number} How many of the most recent releases to build diffs against
+ * @param bundleDownloader Consumer-provided downloader for a released archive
+ * @return The bases that downloaded and verified, newest release first.
+ */
+export async function resolveAssetDiffBases({
+    releaseHistory,
+    diffBaseCount,
+    bundleDownloader,
+    platform,
+    identifier,
+}: {
+    releaseHistory: ReleaseHistoryInterface;
+    diffBaseCount: number;
+    bundleDownloader: NonNullable<CliConfigInterface['bundleDownloader']>;
+    platform: 'ios' | 'android';
+    identifier?: string;
+}): Promise<AssetDiffBase[]> {
+    // The seeded entry for the update inside the app binary has neither a url nor a hash,
+    // and nothing can be diffed against a package that was never published.
+    const candidates = Object.entries(releaseHistory)
+        .filter(([, releaseInfo]) => Boolean(releaseInfo.downloadUrl) && Boolean(releaseInfo.packageHash))
+        .sort(([left], [right]) => semver.rcompare(left, right))
+        .slice(0, diffBaseCount);
+
+    const bases: AssetDiffBase[] = [];
+    for (const [version, releaseInfo] of candidates) {
+        try {
+            const { downloadedFilePath } = await bundleDownloader(releaseInfo.downloadUrl, platform, identifier);
+
+            if (!(await matchesPackageHash(downloadedFilePath, releaseInfo.packageHash))) {
+                console.warn(
+                    `warn: Skipping the asset diff base v${version}: the downloaded archive does not hash to the ` +
+                        `package hash recorded for it (${releaseInfo.packageHash}).`,
+                );
+                continue;
+            }
+
+            bases.push({ basePackageHash: releaseInfo.packageHash, baseBundleFilePath: downloadedFilePath });
+        } catch (error) {
+            console.warn(
+                `warn: Skipping the asset diff base v${version}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    return bases;
+}
+
+/**
+ * Whether an archive holds the contents the release history recorded for it.
+ *
+ * Unpacked into a working directory of its own: the extraction reuses one directory name,
+ * so bases sharing a parent would have the second unpack wipe the first.
+ */
+async function matchesPackageHash(bundleFilePath: string, packageHash: string): Promise<boolean> {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), TEMP_DIR_PREFIX));
+
+    try {
+        const { contentsPath } = await extractCodePushBundleContents(bundleFilePath, tempRoot);
+        // Hashed relative to the contents parent, the way the archive itself was hashed.
+        const actualHash = await generatePackageHashFromDirectory(contentsPath, path.join(contentsPath, '..'));
+        return actualHash === packageHash;
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}

--- a/cli/functions/resolveAssetDiffBases.ts
+++ b/cli/functions/resolveAssetDiffBases.ts
@@ -48,9 +48,12 @@ export async function resolveAssetDiffBases({
     identifier?: string;
 }): Promise<AssetDiffBase[]> {
     // The seeded entry for the update inside the app binary has neither a url nor a hash,
-    // and nothing can be diffed against a package that was never published.
+    // and nothing can be diffed against a package that was never published. A key that is
+    // not a version cannot be ordered against the others either, and ordering is what picks
+    // the recent releases, so it is not eligible.
     const candidates = Object.entries(releaseHistory)
-        .filter(([, releaseInfo]) => Boolean(releaseInfo.downloadUrl) && Boolean(releaseInfo.packageHash))
+        .filter(([version, releaseInfo]) =>
+            Boolean(semver.valid(version)) && Boolean(releaseInfo.downloadUrl) && Boolean(releaseInfo.packageHash))
         .sort(([left], [right]) => semver.rcompare(left, right))
         .slice(0, diffBaseCount);
 

--- a/cli/jest.config.cjs
+++ b/cli/jest.config.cjs
@@ -10,5 +10,7 @@ module.exports = {
     '^.+\\.(t|j)s$': ['babel-jest', { configFile: '../babel.config.js' }],
   },
   moduleFileExtensions: ['ts', 'js'],
+  // `dist` holds the compiled copy of every suite here, which would otherwise run twice.
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   watchman: false,
 };

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
+    "semver": "^7.3.5",
     "shelljs": "^0.10.0",
     "xcode": "^3.0.1",
     "yazl": "^3.3.1",
@@ -29,6 +30,7 @@
     "node": ">=18"
   },
   "devDependencies": {
+    "@types/semver": "^7.5.8",
     "@types/yazl": "^3.3.0",
     "@types/yauzl": "^2.10.3"
   }

--- a/cli/utils/zip.ts
+++ b/cli/utils/zip.ts
@@ -11,6 +11,20 @@ import { walk } from "./promisfied-fs.js";
 type ReleaseFile = { sourceLocation: string, targetLocation: string };
 
 export function zip(updateContentsPath: string): Promise<string> {
+    // For legacy reasons, put the root directory in the zip
+    return zipRelativeTo(updateContentsPath, path.join(updateContentsPath, '..'));
+}
+
+/**
+ * Zips the contents of `rootPath` with entries relative to the root itself, so a file
+ * placed directly under the root lands at the archive root rather than inside a wrapper
+ * directory.
+ */
+export function zipDirectoryContents(rootPath: string): Promise<string> {
+    return zipRelativeTo(rootPath, rootPath);
+}
+
+function zipRelativeTo(updateContentsPath: string, baseDirectoryPath: string): Promise<string> {
 
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
@@ -29,9 +43,6 @@ export function zip(updateContentsPath: string): Promise<string> {
             }
             reject(error);
         }
-
-        const directoryPath = updateContentsPath;
-        const baseDirectoryPath = path.join(directoryPath, '..'); // For legacy reasons, put the root directory in the zip
 
         const files: string[] = await walk(updateContentsPath);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,12 +64,14 @@
       "version": "0.0.0",
       "dependencies": {
         "commander": "^12.1.0",
+        "semver": "^7.3.5",
         "shelljs": "^0.10.0",
         "xcode": "^3.0.1",
         "yauzl": "^3.2.0",
         "yazl": "^3.3.1"
       },
       "devDependencies": {
+        "@types/semver": "^7.5.8",
         "@types/yauzl": "^2.10.3",
         "@types/yazl": "^3.3.0"
       },

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -34,6 +34,13 @@ export interface ReleaseInfo {
      * that cannot use it downloads the full update from `downloadUrl` instead.
      */
     binaryPatchDownloadUrl?: string;
+    /**
+     * URLs of patch archives that also carry an asset diff, keyed by the packageHash of the
+     * release each archive was diffed against. A client whose installed update matches one of
+     * these keys downloads that archive instead of `binaryPatchDownloadUrl`; every other client
+     * ignores this field. Only present when the release was published with asset diff archives.
+     */
+    diffPackages?: Record<string, string>;
     packageHash: string;
     rollout?: number;
 }
@@ -647,6 +654,18 @@ export interface CliConfigInterface {
         platform: "ios" | "android",
         identifier?: string,
     ) => Promise<{downloadUrl: string}>;
+
+    /**
+     * Downloads a previously released update archive so the release command can compute
+     * asset diffs against it. Receives the `downloadUrl` recorded in the release history and
+     * must resolve with the local path of the downloaded file.
+     * Optional: when absent, releases are published without asset diff archives.
+     */
+    bundleDownloader?: (
+        downloadUrl: string,
+        platform: "ios" | "android",
+        identifier?: string,
+    ) => Promise<{ downloadedFilePath: string }>;
 
     /**
      * Interface that must be implemented to retrieve ReleaseHistory information.


### PR DESCRIPTION
## Background

A release published with a binary patch still ships every asset inside the patch archive. Assets dominate the transfer even when none of them changed. This stack teaches a release to also publish per-base **asset diff archives**: for each of the most recent releases, an archive that carries the bundle patch plus only the assets that base does not already hold, and a deletion manifest (`hotcodepush.json`) at the archive root. A client running one of those bases downloads the diff archive instead of the patch archive; everyone else keeps today's behavior.

## Changes

- `makeAssetDiffBundle` builds `<packageHash>-diff-<basePackageHash>.zip` from the patch archive and one base release's full archive. A diff that would not be smaller than the patch archive is skipped.
- `resolveAssetDiffBases` picks the newest releases from the release history, downloads each through the new optional `bundleDownloader` config callback, and re-verifies the archive against its recorded package hash. Any per-base failure (download, verification, build, upload) warns and skips that base — a diff-only problem never fails the release.
- `release` gains `--diff-base-count` (default 3, `0` disables). The history entry records `diffPackages: { basePackageHash: url }`, omitted entirely when no diff was published.
- The cli jest run ignores compiled copies under `dist/`.

## Verification

- New unit tests include a round trip that replays the client's merge order (restore bundle → apply deletions → overlay) and asserts the reconstruction reproduces the full package hash exactly.
- `npm run --workspace cli test`, `npm run type:cli` green.
