### PR TITLE
feat: pass artifact metadata to bundle callbacks

### DIFF
--- a/Examples/CodePushDemoApp/code-push.config.example.firebase.ts
+++ b/Examples/CodePushDemoApp/code-push.config.example.firebase.ts
@@ -2,10 +2,14 @@
 // @ts-nocheck
 
 import {
+    type BundleDownloadInfo,
+    type BundleUploadArtifact,
     CliConfigInterface,
     ReleaseHistoryInterface,
 } from "@bravemobile/react-native-code-push";
 import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import dotenv from "dotenv"; // install as devDependency
 import * as admin from "firebase-admin"; // install as devDependency
 
@@ -38,9 +42,25 @@ function historyJsonFileRemotePath(
 function bundleFileRemotePath(
     platform: "ios" | "android",
     identifier: string,
-    fileName: string,
+    artifact: BundleUploadArtifact,
 ) {
-    return `bundles/${platform}/${identifier}/${fileName}`;
+    if (artifact.type === "full-bundle") {
+        return fullBundleRemotePath(platform, identifier, artifact.packageHash);
+    }
+
+    const artifactPath = artifact.type === "asset-diff"
+        ? `asset-diff/${artifact.targetBinaryVersion}/${artifact.packageHash}/${artifact.basePackageHash}`
+        : `binary-patch/${artifact.targetBinaryVersion}/${artifact.packageHash}`;
+
+    return `bundles/${platform}/${identifier}/${artifactPath}`;
+}
+
+function fullBundleRemotePath(
+    platform: "ios" | "android",
+    identifier: string,
+    packageHash: string,
+) {
+    return `bundles/${platform}/${identifier}/full-bundle/${packageHash}`;
 }
 
 const Config: CliConfigInterface = {
@@ -48,10 +68,14 @@ const Config: CliConfigInterface = {
         source: string,
         platform: "ios" | "android",
         identifier = "staging",
+        artifact,
     ): Promise<{downloadUrl: string}> => {
         try {
-            const fileName = source.split("/").pop();
-            const remotePath = bundleFileRemotePath(platform, identifier, fileName!);
+            if (artifact === undefined) {
+                throw new Error("The release command did not provide bundle artifact metadata.");
+            }
+
+            const remotePath = bundleFileRemotePath(platform, identifier, artifact);
 
             const file = storage.file(remotePath);
 
@@ -141,6 +165,26 @@ const Config: CliConfigInterface = {
             console.error("Error setting release history:", (error as Error).message);
             throw error;
         }
+    },
+
+    bundleDownloader: async (
+        archive: BundleDownloadInfo,
+        platform: "ios" | "android",
+        identifier = "staging",
+    ): Promise<{downloadedFilePath: string}> => {
+        const remotePath = fullBundleRemotePath(
+            platform,
+            identifier,
+            archive.packageHash,
+        );
+        const downloadedFilePath = path.join(
+            os.tmpdir(),
+            `codepush-${archive.releaseVersion}-${archive.packageHash}`,
+        );
+
+        await storage.file(remotePath).download({destination: downloadedFilePath});
+
+        return {downloadedFilePath};
     },
 };
 

--- a/Examples/CodePushDemoApp/code-push.config.example.supabase.ts
+++ b/Examples/CodePushDemoApp/code-push.config.example.supabase.ts
@@ -2,10 +2,14 @@
 // @ts-nocheck
 
 import {
+    type BundleDownloadInfo,
+    type BundleUploadArtifact,
     CliConfigInterface,
     ReleaseHistoryInterface,
 } from "@bravemobile/react-native-code-push";
 import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import axios from "axios"; // install as devDependency
 import * as SupabaseSDK from "@supabase/supabase-js"; // install as devDependency
 
@@ -26,9 +30,25 @@ function historyJsonFileRemotePath(
 function bundleFileRemotePath(
     platform: "ios" | "android",
     identifier: string,
-    fileName: string,
+    artifact: BundleUploadArtifact,
 ) {
-    return `bundles/${platform}/${identifier}/${fileName}`;
+    if (artifact.type === "full-bundle") {
+        return fullBundleRemotePath(platform, identifier, artifact.packageHash);
+    }
+
+    const artifactPath = artifact.type === "asset-diff"
+        ? `asset-diff/${artifact.targetBinaryVersion}/${artifact.packageHash}/${artifact.basePackageHash}`
+        : `binary-patch/${artifact.targetBinaryVersion}/${artifact.packageHash}`;
+
+    return `bundles/${platform}/${identifier}/${artifactPath}`;
+}
+
+function fullBundleRemotePath(
+    platform: "ios" | "android",
+    identifier: string,
+    packageHash: string,
+) {
+    return `bundles/${platform}/${identifier}/full-bundle/${packageHash}`;
 }
 
 const Config: CliConfigInterface = {
@@ -36,10 +56,14 @@ const Config: CliConfigInterface = {
         source: string,
         platform: "ios" | "android",
         identifier = "staging",
+        artifact,
     ): Promise<{downloadUrl: string}> => {
-        const fileName = source.split("/").pop();
+        if (artifact === undefined) {
+            throw new Error("The release command did not provide bundle artifact metadata.");
+        }
+
         const fileStream = fs.createReadStream(source);
-        const remotePath = bundleFileRemotePath(platform, identifier, fileName!);
+        const remotePath = bundleFileRemotePath(platform, identifier, artifact);
 
         const {data, error} = await supabase.storage
             .from(BUCKET_NAME)
@@ -110,6 +134,33 @@ const Config: CliConfigInterface = {
             "Release history File uploaded:",
             `${STORAGE_HOST}/${data.fullPath}`,
         );
+    },
+
+    bundleDownloader: async (
+        archive: BundleDownloadInfo,
+        platform: "ios" | "android",
+        identifier = "staging",
+    ): Promise<{downloadedFilePath: string}> => {
+        const remotePath = fullBundleRemotePath(
+            platform,
+            identifier,
+            archive.packageHash,
+        );
+        const {data, error} = await supabase.storage
+            .from(BUCKET_NAME)
+            .download(remotePath);
+
+        if (error) {
+            throw error;
+        }
+
+        const downloadedFilePath = path.join(
+            os.tmpdir(),
+            `codepush-${archive.releaseVersion}-${archive.packageHash}`,
+        );
+        fs.writeFileSync(downloadedFilePath, Buffer.from(await data.arrayBuffer()));
+
+        return {downloadedFilePath};
     },
 };
 

--- a/Examples/CodePushDemoApp/code-push.config.ts
+++ b/Examples/CodePushDemoApp/code-push.config.ts
@@ -1,8 +1,13 @@
 import axios from "axios";
+import os from "os";
+import path from "path";
 import {
+  type BundleDownloadInfo,
+  type BundleUploadArtifact,
   CliConfigInterface,
   ReleaseHistoryInterface,
 } from "@bravemobile/react-native-code-push";
+import {downloadFileFromS3} from "./scripts/downloadFileFromS3";
 import {invalidateCloudfrontCache} from "./scripts/invalidateCloudfrontCache";
 import {uploadFileToS3} from "./scripts/uploadFileToS3";
 
@@ -19,9 +24,26 @@ function historyJsonFileRemotePath(
 function bundleFileRemotePath(
   platform: "ios" | "android",
   identifier: string,
-  fileName: string,
+  artifact: BundleUploadArtifact,
 ) {
-  return `bundles/${platform}/${identifier}/${fileName}`;
+  if (artifact.type === "full-bundle") {
+    // A package hash identifies full bundle contents across target binary versions.
+    return fullBundleRemotePath(platform, identifier, artifact.packageHash);
+  }
+
+  const artifactPath = artifact.type === "asset-diff"
+    ? `asset-diff/${artifact.targetBinaryVersion}/${artifact.packageHash}/${artifact.basePackageHash}`
+    : `binary-patch/${artifact.targetBinaryVersion}/${artifact.packageHash}`;
+
+  return `bundles/${platform}/${identifier}/${artifactPath}`;
+}
+
+function fullBundleRemotePath(
+  platform: "ios" | "android",
+  identifier: string,
+  packageHash: string,
+) {
+  return `bundles/${platform}/${identifier}/full-bundle/${packageHash}`;
 }
 
 const Config: CliConfigInterface = {
@@ -29,12 +51,16 @@ const Config: CliConfigInterface = {
     source: string,
     platform: "ios" | "android",
     identifier = "staging",
+    artifact,
   ): Promise<{downloadUrl: string}> => {
-    const fileName = source.split("/").pop();
+    if (artifact === undefined) {
+      throw new Error("The release command did not provide bundle artifact metadata.");
+    }
+
     const remoteBundlePath = bundleFileRemotePath(
       platform,
       identifier,
-      fileName!,
+      artifact,
     );
 
     await uploadFileToS3({
@@ -106,6 +132,29 @@ const Config: CliConfigInterface = {
     const jsonUrl = `${CDN_HOST}/${remoteJsonPath}`;
 
     console.log("🎉 Release history File uploaded:", jsonUrl);
+  },
+
+  bundleDownloader: async (
+    archive: BundleDownloadInfo,
+    platform: "ios" | "android",
+    identifier = "staging",
+  ): Promise<{downloadedFilePath: string}> => {
+    const key = fullBundleRemotePath(
+      platform,
+      identifier,
+      archive.packageHash,
+    );
+    const downloadedFilePath = path.join(
+      os.tmpdir(),
+      `codepush-${archive.releaseVersion}-${archive.packageHash}`,
+    );
+
+    await downloadFileFromS3({
+      pathToLocalFile: downloadedFilePath,
+      key,
+    });
+
+    return {downloadedFilePath};
   },
 };
 

--- a/Examples/CodePushDemoApp/scripts/awsConstants.ts
+++ b/Examples/CodePushDemoApp/scripts/awsConstants.ts
@@ -1,0 +1,10 @@
+export const AWS_REGION = "ap-northeast-2";
+
+export const AWS_CREDENTIALS = {
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+};
+
+export const CODE_PUSH_S3_BUCKET_NAME = "code-push-bucket";
+
+export const CLOUDFRONT_DISTRIBUTION_ID = "DISTRIBUTION_ID";

--- a/Examples/CodePushDemoApp/scripts/downloadFileFromS3.ts
+++ b/Examples/CodePushDemoApp/scripts/downloadFileFromS3.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import {GetObjectCommand, S3Client} from "@aws-sdk/client-s3";
+import {
+  AWS_CREDENTIALS,
+  AWS_REGION,
+  CODE_PUSH_S3_BUCKET_NAME,
+} from "./awsConstants";
+
+interface Params {
+  pathToLocalFile: string;
+  key: string;
+}
+
+export async function downloadFileFromS3({pathToLocalFile, key}: Params) {
+  const s3Client = new S3Client({
+    region: AWS_REGION,
+    credentials: AWS_CREDENTIALS,
+  });
+
+  const response = await s3Client.send(new GetObjectCommand({
+    Bucket: CODE_PUSH_S3_BUCKET_NAME,
+    Key: key,
+  }));
+
+  if (!response.Body) {
+    throw new Error(`S3 object "${key}" has no response body.`);
+  }
+
+  await fs.promises.writeFile(
+    pathToLocalFile,
+    await response.Body.transformToByteArray(),
+  );
+}

--- a/Examples/CodePushDemoApp/scripts/invalidateCloudfrontCache.ts
+++ b/Examples/CodePushDemoApp/scripts/invalidateCloudfrontCache.ts
@@ -2,20 +2,17 @@ import {
   CloudFrontClient,
   CreateInvalidationCommand,
 } from "@aws-sdk/client-cloudfront";
-
-const CLOUDFRONT_DISTRIBUTION_ID = "DISTRIBUTION_ID";
-
-const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+import {
+  AWS_CREDENTIALS,
+  AWS_REGION,
+  CLOUDFRONT_DISTRIBUTION_ID,
+} from "./awsConstants";
 
 export async function invalidateCloudfrontCache({key}: {key: string}) {
   console.log(`log: Start creating cache invalidation (${key})`);
   const cloudfront = new CloudFrontClient({
-    region: "ap-northeast-2",
-    credentials: {
-      accessKeyId: AWS_ACCESS_KEY_ID!,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY!,
-    },
+    region: AWS_REGION,
+    credentials: AWS_CREDENTIALS,
   });
 
   const command = new CreateInvalidationCommand({

--- a/Examples/CodePushDemoApp/scripts/uploadFileToS3.ts
+++ b/Examples/CodePushDemoApp/scripts/uploadFileToS3.ts
@@ -1,10 +1,11 @@
 import fs from "fs";
 import {S3Client} from "@aws-sdk/client-s3";
 import {Upload} from "@aws-sdk/lib-storage";
-
-const BUCKET_NAME = "code-push-bucket";
-const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+import {
+  AWS_CREDENTIALS,
+  AWS_REGION,
+  CODE_PUSH_S3_BUCKET_NAME,
+} from "./awsConstants";
 
 interface Params {
   pathToLocalFile: string;
@@ -13,11 +14,8 @@ interface Params {
 
 export async function uploadFileToS3({pathToLocalFile, key}: Params) {
   const s3Client = new S3Client({
-    region: "ap-northeast-2",
-    credentials: {
-      accessKeyId: AWS_ACCESS_KEY_ID!,
-      secretAccessKey: AWS_SECRET_ACCESS_KEY!,
-    },
+    region: AWS_REGION,
+    credentials: AWS_CREDENTIALS,
   });
 
   const fileStream = fs.createReadStream(pathToLocalFile);
@@ -25,7 +23,7 @@ export async function uploadFileToS3({pathToLocalFile, key}: Params) {
   const uploader = new Upload({
     client: s3Client,
     params: {
-      Bucket: BUCKET_NAME,
+      Bucket: CODE_PUSH_S3_BUCKET_NAME,
       Key: key,
       Body: fileStream,
       ACL: "public-read",

--- a/README.md
+++ b/README.md
@@ -351,9 +351,10 @@ Diff archives are published only when all three of these hold:
 - `--diff-base-count` is greater than `0` (it defaults to `3`).
 
 ```ts
-bundleDownloader: async (downloadUrl) => {
-    const downloadedFilePath = path.join(os.tmpdir(), path.basename(new URL(downloadUrl).pathname));
-    // fetch the archive from your storage (S3, GCS, ...) to downloadedFilePath
+bundleDownloader: async (archive, platform, identifier = 'staging') => {
+    const downloadedFilePath = path.join(os.tmpdir(), archive.packageHash);
+    const storageKey = `bundles/${platform}/${identifier}/full-bundle/${archive.packageHash}`;
+    // fetch storageKey from your storage (S3, Supabase, ...) to downloadedFilePath
     return { downloadedFilePath };
 },
 ```
@@ -389,6 +390,7 @@ const Config: CliConfigInterface = {
     source: string,
     platform: "ios" | "android",
     identifier,
+    artifact,
   ): Promise<{downloadUrl: string}> => {
     // ...
   },
@@ -413,7 +415,7 @@ const Config: CliConfigInterface = {
 
   // Only needed to publish asset diff archives (see "4-2. Asset Diff Archives").
   // bundleDownloader: async (
-  //   downloadUrl: string,
+  //   archive,
   //   platform: "ios" | "android",
   //   identifier,
   // ): Promise<{downloadedFilePath: string}> => {
@@ -427,6 +429,9 @@ module.exports = Config;
 
 **`bundleUploader`**
 - Implements a function to upload the bundle file.
+- The optional `artifact` argument identifies the full bundle, binary patch, or asset diff
+  archive. The `release` command always provides it, including the target binary version and
+  the package hashes needed to construct a storage key without parsing a file name.
 - The `downloadUrl` returned by this function is recorded in `ReleaseHistoryInterface` data
   and is used by the library runtime to download the bundle file from this URL.
 - Used in the following cases:

--- a/cli/README.ko.md
+++ b/cli/README.ko.md
@@ -29,10 +29,12 @@ CLI는 프로젝트 루트에 `code-push.config.ts` (또는 `.js`) 파일이 필
 
 | 함수 | 설명 | 필수 여부 |
 |------|------|-----------|
-| `bundleUploader(source, platform, identifier?)` | 번들 파일을 업로드하고, 내려받을 수 있는 `downloadUrl`을 반환합니다 | 필수 |
+| `bundleUploader(source, platform, identifier?, artifact?)` | 번들 파일을 업로드하고, 내려받을 수 있는 `downloadUrl`을 반환합니다. `artifact`에는 full bundle, binary patch, asset diff archive의 종류와 대상 바이너리 버전, package hash가 담깁니다 | 필수 |
 | `getReleaseHistory(targetBinaryVersion, platform, identifier?)` | 바이너리 버전의 릴리스 히스토리를 반환합니다 | 필수 |
 | `setReleaseHistory(targetBinaryVersion, jsonFilePath, releaseInfo, platform, identifier?)` | 바이너리 버전의 릴리스 히스토리를 생성하거나 덮어씁니다 | 필수 |
-| `bundleDownloader(downloadUrl, platform, identifier?)` | 릴리스 히스토리에 기록된 `downloadUrl`에서 배포된 archive를 내려받아 로컬 경로를 `downloadedFilePath`로 반환합니다. [asset diff archive](#asset-diff-archive)를 만들 기준이 되는 base 릴리스를 가져올 때만 사용합니다 | 선택 |
+| `bundleDownloader(archive, platform, identifier?)` | 배포된 archive를 내려받아 로컬 경로를 `downloadedFilePath`로 반환합니다. `archive`에는 `downloadUrl`, 기준 full bundle의 대상 바이너리 버전, 릴리스 버전과 package hash가 담기므로 URL을 파싱해 스토리지 키를 만들 필요가 없습니다. [asset diff archive](#asset-diff-archive)를 만들 기준 릴리스를 가져올 때만 사용합니다 | 선택 |
+
+`artifact`로 스토리지 키를 만들 때 full bundle에는 `targetBinaryVersion`을 넣지 않아도 됩니다. `packageHash`가 대상 바이너리 버전과 무관하게 같은 내용을 식별하기 때문입니다. binary patch와 asset diff archive는 대상 바이너리에 포함된 JS bundle을 기준으로 만들어지므로 반드시 이 값을 포함해야 합니다.
 
 > 전체 구현 예시를 참고하세요:
 > - [AWS S3 + CloudFront 예시](../Examples/CodePushDemoApp/code-push.config.ts)

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,10 +29,12 @@ You need a `code-push.config.ts` (or `.js`) file at your project root. It export
 
 | Function | Description | Required |
 |----------|-------------|----------|
-| `bundleUploader(source, platform, identifier?)` | Uploads a bundle file and returns the `downloadUrl` it can be downloaded from | Yes |
+| `bundleUploader(source, platform, identifier?, artifact?)` | Uploads a bundle file and returns the `downloadUrl` it can be downloaded from. `artifact` identifies the full bundle, binary patch, or asset diff archive, including its target binary version and package hashes | Yes |
 | `getReleaseHistory(targetBinaryVersion, platform, identifier?)` | Returns the release history of a binary version | Yes |
 | `setReleaseHistory(targetBinaryVersion, jsonFilePath, releaseInfo, platform, identifier?)` | Creates or overwrites the release history of a binary version | Yes |
-| `bundleDownloader(downloadUrl, platform, identifier?)` | Downloads a released archive from a `downloadUrl` recorded in the release history and returns its local path as `downloadedFilePath`. Only used to fetch the releases that [asset diff archives](#asset-diff-archives) are built against | No |
+| `bundleDownloader(archive, platform, identifier?)` | Downloads a released archive and returns its local path as `downloadedFilePath`. `archive` contains its `downloadUrl`, target binary version, release version, and package hash, so storage keys do not need to be derived from the URL. Only used to fetch the releases that [asset diff archives](#asset-diff-archives) are built against | No |
+
+When deriving storage keys from `artifact`, you can omit `targetBinaryVersion` for a full bundle: its `packageHash` identifies the same contents across target binary versions. Binary patches and asset diff archives must include it because their contents depend on the JS bundle embedded in that target binary.
 
 > Implementation examples:
 > - [AWS S3 + CloudFront](../Examples/CodePushDemoApp/code-push.config.ts)

--- a/cli/commands/releaseCommand/release.test.ts
+++ b/cli/commands/releaseCommand/release.test.ts
@@ -17,7 +17,7 @@ import {
 import { applyPatch } from "../../utils/binaryPatch.js";
 import { generatePackageHashFromDirectory } from "../../utils/hash-utils.js";
 import { unzip } from "../../utils/unzip.js";
-import type { CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
+import type { BundleUploadArtifact, CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
 
 /**
  * Covers the release flow around the binary patch option with `--skip-bundle`, which is
@@ -92,15 +92,23 @@ class ProcessExitError extends Error {
     }
 }
 
-type Uploads = { filePath: string, downloadUrl: string, logCountBeforeUpload: number }[];
+type Uploads = {
+    artifact: BundleUploadArtifact | undefined;
+    downloadUrl: string;
+    filePath: string;
+    logCountBeforeUpload: number;
+}[];
 
-function recordingUploader(uploads: Uploads, failOn?: (filePath: string) => boolean) {
-    return async (filePath: string) => {
+function recordingUploader(
+    uploads: Uploads,
+    failOn?: (filePath: string) => boolean,
+): CliConfigInterface['bundleUploader'] {
+    return async (filePath, _platform, _identifier, artifact) => {
         if (failOn?.(filePath)) {
             throw new Error(`upload rejected: ${path.basename(filePath)}`);
         }
         const downloadUrl = `https://cdn.example.com/${path.basename(filePath)}`;
-        uploads.push({ filePath, downloadUrl, logCountBeforeUpload: logs.length });
+        uploads.push({ artifact, filePath, downloadUrl, logCountBeforeUpload: logs.length });
         return { downloadUrl };
     };
 }
@@ -204,6 +212,17 @@ afterEach(() => {
 });
 
 describe("release without --binary-bundle-path", () => {
+    it("keeps existing three-argument uploaders callable", async () => {
+        const legacyUploader = async (
+            source: string,
+            _platform: 'ios' | 'android',
+            _identifier?: string,
+        ) => ({ downloadUrl: source });
+        const uploader: CliConfigInterface['bundleUploader'] = legacyUploader;
+
+        await expect(uploader('bundle.zip', 'ios')).resolves.toEqual({ downloadUrl: 'bundle.zip' });
+    });
+
     it("uploads the full bundle only, exactly as before binary patches existed", async () => {
         const staged = await stageBundleOutput("full-only");
 
@@ -211,6 +230,11 @@ describe("release without --binary-bundle-path", () => {
 
         expect(uploads).toHaveLength(1);
         expect(uploads[0].filePath).toBe(`${staged.bundleDirectory}/${staged.bundleFileName}`);
+        expect(uploads[0].artifact).toEqual({
+            type: 'full-bundle',
+            targetBinaryVersion: BINARY_VERSION,
+            packageHash: staged.bundleFileName,
+        });
         expect(fs.readdirSync(staged.bundleDirectory)).toEqual([staged.bundleFileName]);
         expect(releaseHistories[0][APP_VERSION]).toEqual({
             enabled: true,
@@ -658,11 +682,11 @@ describe("release with asset diff bases", () => {
 
     /** Serves the staged base archives, and records which releases were asked for. */
     function recordingDownloader(bases: StagedBaseRelease[], downloads: string[]): CliConfigInterface['bundleDownloader'] {
-        return async (downloadUrl: string) => {
-            downloads.push(downloadUrl);
-            const base = bases.find((candidate) => candidate.downloadUrl === downloadUrl);
+        return async (archive) => {
+            downloads.push(archive.downloadUrl);
+            const base = bases.find((candidate) => candidate.downloadUrl === archive.downloadUrl);
             if (!base) {
-                throw new Error(`the downloader was called with an unexpected url: ${downloadUrl}`);
+                throw new Error(`the downloader was called with an unexpected url: ${archive.downloadUrl}`);
             }
             return { downloadedFilePath: base.archivePath };
         };
@@ -686,6 +710,24 @@ describe("release with asset diff bases", () => {
             staged.bundleFileName,
             `${staged.bundleFileName}${BINARY_PATCH_ARCHIVE_SUFFIX}`,
             diffFileName,
+        ]);
+        expect(uploads.map(({ artifact }) => artifact)).toEqual([
+            {
+                type: 'full-bundle',
+                targetBinaryVersion: BINARY_VERSION,
+                packageHash: staged.bundleFileName,
+            },
+            {
+                type: 'binary-patch',
+                targetBinaryVersion: BINARY_VERSION,
+                packageHash: staged.bundleFileName,
+            },
+            {
+                type: 'asset-diff',
+                targetBinaryVersion: BINARY_VERSION,
+                packageHash: staged.bundleFileName,
+                basePackageHash: base.packageHash,
+            },
         ]);
         expect(downloads).toEqual([base.downloadUrl]);
         // Every artifact is uploaded before the history points at any of them.

--- a/cli/commands/releaseCommand/release.ts
+++ b/cli/commands/releaseCommand/release.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { bundleCodePush, resolveJsBundleName } from "../bundleCommand/bundleCodePush.js";
 import { addToReleaseHistory } from "./addToReleaseHistory.js";
-import type { CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
+import type { BundleUploadArtifact, CliConfigInterface, ReleaseHistoryInterface } from "../../../typings/react-native-code-push.d.ts";
 import { generatePackageHashFromDirectory } from "../../utils/hash-utils.js";
 import { unzip } from "../../utils/unzip.js";
 import { ASSET_DIFF_ARCHIVE_INFIX, makeAssetDiffBundle } from "../../functions/makeAssetDiffBundle.js";
@@ -95,6 +95,7 @@ export async function release(
             bundleDownloader,
             bundleDirectory,
             packageHash,
+            targetBinaryVersion: binaryVersion,
             platform,
             identifier,
         })
@@ -102,10 +103,32 @@ export async function release(
 
     // Every artifact is uploaded before the release history is touched, so a failed
     // upload leaves the history describing only updates that can actually be downloaded.
-    const downloadUrl = await uploadArtifact(bundleUploader, bundleFilePath, platform, identifier, 'bundle');
+    const downloadUrl = await uploadArtifact(
+        bundleUploader,
+        bundleFilePath,
+        platform,
+        identifier,
+        {
+            type: 'full-bundle',
+            targetBinaryVersion: binaryVersion,
+            packageHash,
+        },
+        'bundle',
+    );
     let patchDownloadUrl: string | undefined;
     if (binaryPatch) {
-        patchDownloadUrl = await uploadArtifact(bundleUploader, binaryPatch.patchBundleFilePath, platform, identifier, 'binary patch bundle');
+        patchDownloadUrl = await uploadArtifact(
+            bundleUploader,
+            binaryPatch.patchBundleFilePath,
+            platform,
+            identifier,
+            {
+                type: 'binary-patch',
+                targetBinaryVersion: binaryVersion,
+                packageHash,
+            },
+            'binary patch bundle',
+        );
         console.log(`log: Binary patch archive uploaded (download url: ${patchDownloadUrl})`);
     }
     const diffPackages: Record<string, string> = {};
@@ -114,7 +137,12 @@ export async function release(
         // one that cannot be uploaded is left out of the history instead of failing the
         // release the other two artifacts are ready for.
         try {
-            const diffDownloadUrl = await uploadFile(bundleUploader, filePath, platform, identifier);
+            const diffDownloadUrl = await uploadFile(bundleUploader, filePath, platform, identifier, {
+                type: 'asset-diff',
+                targetBinaryVersion: binaryVersion,
+                packageHash,
+                basePackageHash,
+            });
             diffPackages[basePackageHash] = diffDownloadUrl;
             console.log(`log: Asset diff archive against ${basePackageHash} uploaded (download url: ${diffDownloadUrl})`);
         } catch (error) {
@@ -289,6 +317,7 @@ async function makeAssetDiffArtifacts({
     bundleDownloader,
     bundleDirectory,
     packageHash,
+    targetBinaryVersion,
     platform,
     identifier,
 }: {
@@ -298,6 +327,7 @@ async function makeAssetDiffArtifacts({
     bundleDownloader: NonNullable<CliConfigInterface['bundleDownloader']>;
     bundleDirectory: string;
     packageHash: string;
+    targetBinaryVersion: string;
     platform: 'ios' | 'android';
     identifier: string | undefined;
 }): Promise<AssetDiffArtifact[]> {
@@ -307,6 +337,7 @@ async function makeAssetDiffArtifacts({
         bundleDownloader,
         platform,
         identifier,
+        targetBinaryVersion,
     });
 
     const artifacts: AssetDiffArtifact[] = [];
@@ -421,10 +452,11 @@ async function uploadArtifact(
     filePath: string,
     platform: 'ios' | 'android',
     identifier: string | undefined,
+    artifact: BundleUploadArtifact,
     artifactName: string,
 ): Promise<string> {
     try {
-        return await uploadFile(bundleUploader, filePath, platform, identifier);
+        return await uploadFile(bundleUploader, filePath, platform, identifier, artifact);
     } catch (error) {
         console.error(`Failed to upload the ${artifactName} file. Exiting the program.\n`, error)
         process.exit(1)
@@ -436,7 +468,8 @@ async function uploadFile(
     filePath: string,
     platform: 'ios' | 'android',
     identifier: string | undefined,
+    artifact: BundleUploadArtifact,
 ): Promise<string> {
-    const { downloadUrl } = await bundleUploader(filePath, platform, identifier);
+    const { downloadUrl } = await bundleUploader(filePath, platform, identifier, artifact);
     return downloadUrl
 }

--- a/cli/functions/resolveAssetDiffBases.test.ts
+++ b/cli/functions/resolveAssetDiffBases.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
 import { makeCodePushBundle } from "./makeCodePushBundle.js";
 import { resolveAssetDiffBases } from "./resolveAssetDiffBases.js";
-import type { CliConfigInterface, ReleaseHistoryInterface } from "../../typings/react-native-code-push.d.ts";
+import type { BundleDownloadInfo, CliConfigInterface, ReleaseHistoryInterface } from "../../typings/react-native-code-push.d.ts";
 
 /**
  * Exercises base acquisition against real archives and real hashes: a base is only usable
@@ -17,6 +17,7 @@ const CONTENTS_DIR_NAME = 'CodePush';
 
 /** Where the resolver unpacks a base for verification, so leftovers are recognizable. */
 const TEMP_DIR_PREFIX = 'codepush-asset-diff-base-';
+const TARGET_BINARY_VERSION = '1.0.0';
 
 type StagedRelease = {
     version: string;
@@ -68,22 +69,22 @@ function releaseHistoryOf(releases: StagedRelease[]): ReleaseHistoryInterface {
 
 /** Stands in for the consumer's downloader: hands back a local archive per download url. */
 function fakeDownloader(archives: Record<string, string | Error>) {
-    const calls: Array<[string, string, string | undefined]> = [];
+    const calls: Array<[BundleDownloadInfo, string, string | undefined]> = [];
     const download: NonNullable<CliConfigInterface['bundleDownloader']> = async (
-        downloadUrl,
+        downloadInfo,
         platform,
         identifier,
     ) => {
-        calls.push([downloadUrl, platform, identifier]);
+        calls.push([downloadInfo, platform, identifier]);
 
-        const archive = archives[downloadUrl];
-        if (archive instanceof Error) {
-            throw archive;
+        const downloadedArchive = archives[downloadInfo.downloadUrl];
+        if (downloadedArchive instanceof Error) {
+            throw downloadedArchive;
         }
-        if (!archive) {
-            throw new Error(`the downloader was called with an unexpected url: ${downloadUrl}`);
+        if (!downloadedArchive) {
+            throw new Error(`the downloader was called with an unexpected url: ${downloadInfo.downloadUrl}`);
         }
-        return { downloadedFilePath: archive };
+        return { downloadedFilePath: downloadedArchive };
     };
     return { download, calls };
 }
@@ -119,6 +120,7 @@ describe("resolveAssetDiffBases", () => {
             bundleDownloader: download,
             platform: 'android',
             identifier: 'my-app',
+            targetBinaryVersion: TARGET_BINARY_VERSION,
         });
 
         expect(bases).toEqual([
@@ -126,8 +128,8 @@ describe("resolveAssetDiffBases", () => {
             { basePackageHash: second.packageHash, baseBundleFilePath: second.archivePath },
         ]);
         expect(calls).toEqual([
-            [newest.downloadUrl, 'android', 'my-app'],
-            [second.downloadUrl, 'android', 'my-app'],
+            [{ downloadUrl: newest.downloadUrl, targetBinaryVersion: TARGET_BINARY_VERSION, releaseVersion: newest.version, packageHash: newest.packageHash }, 'android', 'my-app'],
+            [{ downloadUrl: second.downloadUrl, targetBinaryVersion: TARGET_BINARY_VERSION, releaseVersion: second.version, packageHash: second.packageHash }, 'android', 'my-app'],
         ]);
     });
 
@@ -145,12 +147,17 @@ describe("resolveAssetDiffBases", () => {
             diffBaseCount: 1,
             bundleDownloader: download,
             platform: 'ios',
+            targetBinaryVersion: TARGET_BINARY_VERSION,
         });
 
         expect(bases).toEqual([
             { basePackageHash: released.packageHash, baseBundleFilePath: released.archivePath },
         ]);
-        expect(calls).toEqual([[released.downloadUrl, 'ios', undefined]]);
+        expect(calls).toEqual([[
+            { downloadUrl: released.downloadUrl, targetBinaryVersion: TARGET_BINARY_VERSION, releaseVersion: released.version, packageHash: released.packageHash },
+            'ios',
+            undefined,
+        ]]);
     });
 
     it("ignores a history entry whose key is not a version, and resolves the rest", async () => {
@@ -170,12 +177,17 @@ describe("resolveAssetDiffBases", () => {
             diffBaseCount: 2,
             bundleDownloader: download,
             platform: 'ios',
+            targetBinaryVersion: TARGET_BINARY_VERSION,
         });
 
         expect(bases).toEqual([
             { basePackageHash: released.packageHash, baseBundleFilePath: released.archivePath },
         ]);
-        expect(calls).toEqual([[released.downloadUrl, 'ios', undefined]]);
+        expect(calls).toEqual([[
+            { downloadUrl: released.downloadUrl, targetBinaryVersion: TARGET_BINARY_VERSION, releaseVersion: released.version, packageHash: released.packageHash },
+            'ios',
+            undefined,
+        ]]);
     });
 
     it("drops a base whose downloaded bytes do not match its recorded package hash", async () => {
@@ -192,6 +204,7 @@ describe("resolveAssetDiffBases", () => {
             diffBaseCount: 2,
             bundleDownloader: download,
             platform: 'android',
+            targetBinaryVersion: TARGET_BINARY_VERSION,
         });
 
         expect(bases).toEqual([{ basePackageHash: older.packageHash, baseBundleFilePath: older.archivePath }]);
@@ -212,6 +225,7 @@ describe("resolveAssetDiffBases", () => {
             diffBaseCount: 2,
             bundleDownloader: download,
             platform: 'android',
+            targetBinaryVersion: TARGET_BINARY_VERSION,
         });
 
         expect(bases).toEqual([{ basePackageHash: older.packageHash, baseBundleFilePath: older.archivePath }]);

--- a/cli/functions/resolveAssetDiffBases.ts
+++ b/cli/functions/resolveAssetDiffBases.ts
@@ -40,12 +40,14 @@ export async function resolveAssetDiffBases({
     bundleDownloader,
     platform,
     identifier,
+    targetBinaryVersion,
 }: {
     releaseHistory: ReleaseHistoryInterface;
     diffBaseCount: number;
     bundleDownloader: NonNullable<CliConfigInterface['bundleDownloader']>;
     platform: 'ios' | 'android';
     identifier?: string;
+    targetBinaryVersion: string;
 }): Promise<AssetDiffBase[]> {
     // The seeded entry for the update inside the app binary has neither a url nor a hash,
     // and nothing can be diffed against a package that was never published. A key that is
@@ -60,7 +62,12 @@ export async function resolveAssetDiffBases({
     const bases: AssetDiffBase[] = [];
     for (const [version, releaseInfo] of candidates) {
         try {
-            const { downloadedFilePath } = await bundleDownloader(releaseInfo.downloadUrl, platform, identifier);
+            const { downloadedFilePath } = await bundleDownloader({
+                downloadUrl: releaseInfo.downloadUrl,
+                targetBinaryVersion,
+                releaseVersion: version,
+                packageHash: releaseInfo.packageHash,
+            }, platform, identifier);
 
             if (!(await matchesPackageHash(downloadedFilePath, releaseInfo.packageHash))) {
                 console.warn(

--- a/e2e/README.ko.md
+++ b/e2e/README.ko.md
@@ -126,14 +126,14 @@ e2e/
 ### Mock 서버
 
 실제 CodePush 서버 대신, 로컬 Express 서버가 다음을 서빙합니다:
-- **번들**: `mock-server/data/bundles/{platform}/{identifier}/`
+- **번들**: `mock-server/data/bundles/{platform}/{identifier}/full-bundle/{packageHash}`와 `mock-server/data/bundles/{platform}/{identifier}/{artifactType}/{targetBinaryVersion}/`
 - **릴리스 히스토리**: `mock-server/data/histories/{platform}/{identifier}/{version}.json`
 
-`code-push.config.local.ts` 템플릿은 모든 CLI 작업(업로드, 히스토리 읽기/쓰기)을 로컬 파일시스템으로 라우팅하며, 앱의 `CODEPUSH_HOST`는 mock 서버를 가리키도록 패치됩니다. 바이너리 패치와 함께 배포된 릴리스는 full archive 옆에 `{packageHash}-patch.zip` 이름으로 두 번째 archive를 저장합니다.
+`code-push.config.local.ts` 템플릿은 모든 CLI 작업(업로드, 히스토리 읽기/쓰기)을 로컬 파일시스템으로 라우팅하며, 앱의 `CODEPUSH_HOST`는 mock 서버를 가리키도록 패치됩니다. 업로더가 전달한 artifact metadata로 스토리지 키를 만들므로 archive 파일명에 의존하지 않습니다.
 
 서버는 응답한 모든 요청을 기록합니다. 러너는 이 기록을 되읽어, 화면으로는 구분할 수 없는 것 — 앱이 어떤 업데이트 archive를 어떤 순서로 내려받았는지 — 를 검증합니다.
 
-`E2E_ARTIFACT_LOG_PATH`가 주어지면 템플릿은 저장한 모든 artifact도 (서빙 디렉터리 바깥에) 기록하며, 러너는 이를 되읽어 번들과 릴리스 히스토리가 계속 `{platform}/{identifier}` 아래에 저장되는지 검증합니다.
+`E2E_ARTIFACT_LOG_PATH`가 주어지면 템플릿은 저장한 모든 artifact도 (서빙 디렉터리 바깥에) 기록하며, 러너는 이를 되읽어 번들과 릴리스 히스토리가 metadata 기반 경로에 저장되는지 검증합니다.
 
 ### 릴리스 마커
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -126,14 +126,14 @@ e2e/
 ### Mock Server
 
 Instead of a real CodePush server, tests use a local Express server that serves:
-- **Bundles**: `mock-server/data/bundles/{platform}/{identifier}/`
+- **Bundles**: `mock-server/data/bundles/{platform}/{identifier}/full-bundle/{packageHash}` and `mock-server/data/bundles/{platform}/{identifier}/{artifactType}/{targetBinaryVersion}/`
 - **Release history**: `mock-server/data/histories/{platform}/{identifier}/{version}.json`
 
-The `code-push.config.local.ts` template routes all CLI operations (upload, history read/write) to this local filesystem, and the app's `CODEPUSH_HOST` is patched to point at the mock server. A release published with a binary patch stores a second archive next to the full one, named `{packageHash}-patch.zip`.
+The `code-push.config.local.ts` template routes all CLI operations (upload, history read/write) to this local filesystem, and the app's `CODEPUSH_HOST` is patched to point at the mock server. It uses the uploader's artifact metadata for the storage key, so its layout does not depend on archive filenames.
 
 The server records every request it answers. Reading that log back is how the runner tells apart cases the screen cannot: which update archives the app downloaded, and in which order.
 
-When the config template is given `E2E_ARTIFACT_LOG_PATH`, it also records every artifact it stores (outside the served directory), which the runner reads back to assert that bundles and release histories keep landing under `{platform}/{identifier}`.
+When the config template is given `E2E_ARTIFACT_LOG_PATH`, it also records every artifact it stores (outside the served directory), which the runner reads back to assert that bundles and release histories keep landing under their metadata-based paths.
 
 ### Release Markers
 

--- a/e2e/helpers/artifact-storage.ts
+++ b/e2e/helpers/artifact-storage.ts
@@ -7,16 +7,19 @@ import { ARTIFACT_LOG_PATH, MOCK_DATA_DIR } from "../config";
  * template writes.
  *
  * The point of reading it back is that the storage layout is a contract between the CLI
- * and whatever hosts the artifacts: bundles live under `{platform}/{identifier}`, and a
- * release history under `{platform}/{identifier}/{binaryVersion}.json`. Publishing a
- * binary patch adds a second archive per release, and it has to land in the same place
- * as the full one rather than somewhere of its own.
+ * and whatever hosts the artifacts: a full bundle uses its package hash under
+ * `{platform}/{identifier}/full-bundle`, while binary patches and asset diffs use their
+ * target binary version under `{platform}/{identifier}/{artifactType}`. A release history
+ * lives under `{platform}/{identifier}/{binaryVersion}.json`.
  */
 export interface StoredBundleArtifact {
   kind: "bundle";
   platform: string;
   identifier: string;
-  fileName: string;
+  artifactType: "full-bundle" | "binary-patch" | "asset-diff";
+  targetBinaryVersion: string;
+  packageHash: string;
+  basePackageHash?: string;
   storedPath: string;
   downloadUrl: string;
 }
@@ -30,9 +33,6 @@ export interface StoredHistoryArtifact {
 }
 
 export type StoredArtifact = StoredBundleArtifact | StoredHistoryArtifact;
-
-/** Appended to the full archive name so the two artifacts of a release stay paired. */
-export const PATCH_ARCHIVE_SUFFIX = "-patch.zip";
 
 export function clearArtifactLog(): void {
   fs.rmSync(ARTIFACT_LOG_PATH, { force: true });
@@ -66,7 +66,7 @@ export function assertArtifactStorageLayout(scenario: string): StoredArtifact[] 
 
   for (const artifact of artifacts) {
     const expectedPath = artifact.kind === "bundle"
-      ? path.join("bundles", artifact.platform, artifact.identifier, artifact.fileName)
+      ? bundleStoredPath(artifact)
       : path.join("histories", artifact.platform, artifact.identifier, `${artifact.binaryVersion}.json`);
 
     if (artifact.storedPath !== expectedPath) {
@@ -80,22 +80,59 @@ export function assertArtifactStorageLayout(scenario: string): StoredArtifact[] 
     }
   }
 
-  // The full archive of a release is stored under its package hash, and the patch archive
-  // next to it under the same hash with the patch suffix.
-  for (const patchArchive of bundles.filter((bundle) => bundle.fileName.endsWith(PATCH_ARCHIVE_SUFFIX))) {
-    const packageHash = patchArchive.fileName.slice(0, -PATCH_ARCHIVE_SUFFIX.length);
+  // Binary patches and full bundles share the same package hash and target binary version.
+  for (const patchArchive of bundles.filter((bundle) => bundle.artifactType === "binary-patch")) {
     const fullArchive = bundles.find((bundle) =>
       bundle.platform === patchArchive.platform
       && bundle.identifier === patchArchive.identifier
-      && bundle.fileName === packageHash);
+      && bundle.artifactType === "full-bundle"
+      && bundle.targetBinaryVersion === patchArchive.targetBinaryVersion
+      && bundle.packageHash === patchArchive.packageHash);
 
     if (!fullArchive) {
       throw new Error(
-        `${scenario}: patch archive "${patchArchive.storedPath}" has no full archive of the same release beside it`,
+        `${scenario}: patch archive "${patchArchive.storedPath}" has no matching full archive`,
       );
     }
   }
 
-  console.log(`[assert] ${scenario}: ${artifacts.length} artifacts stored under {platform}/{identifier}`);
+  console.log(`[assert] ${scenario}: ${artifacts.length} artifacts stored under metadata-based paths`);
   return artifacts;
+}
+
+function bundleStoredPath(artifact: StoredBundleArtifact): string {
+  if (artifact.artifactType === "full-bundle") {
+    return path.join(
+      "bundles",
+      artifact.platform,
+      artifact.identifier,
+      artifact.artifactType,
+      artifact.packageHash,
+    );
+  }
+
+  if (artifact.artifactType === "asset-diff") {
+    if (artifact.basePackageHash === undefined) {
+      throw new Error(`Asset diff "${artifact.storedPath}" is missing its base package hash`);
+    }
+
+    return path.join(
+      "bundles",
+      artifact.platform,
+      artifact.identifier,
+      artifact.artifactType,
+      artifact.targetBinaryVersion,
+      artifact.packageHash,
+      artifact.basePackageHash,
+    );
+  }
+
+  return path.join(
+    "bundles",
+    artifact.platform,
+    artifact.identifier,
+    artifact.artifactType,
+    artifact.targetBinaryVersion,
+    artifact.packageHash,
+  );
 }

--- a/e2e/helpers/binary-patch-fixtures.ts
+++ b/e2e/helpers/binary-patch-fixtures.ts
@@ -3,7 +3,6 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { MOCK_DATA_DIR, WORK_DIR } from "../config";
-import { PATCH_ARCHIVE_SUFFIX } from "./artifact-storage";
 
 /**
  * Fixtures for the binary patch scenarios: the base bundle a patch is computed against,
@@ -148,7 +147,7 @@ export function assertReleaseOffersPatch(
   }
 
   const patchDownloadUrl = release.binaryPatchDownloadUrl;
-  if (!patchDownloadUrl || !patchDownloadUrl.endsWith(PATCH_ARCHIVE_SUFFIX)) {
+  if (!patchDownloadUrl) {
     throw new Error(
       `${scenario}: v${releaseVersion} was published without a binary patch (binaryPatchDownloadUrl: ${String(patchDownloadUrl)})`,
     );
@@ -227,25 +226,42 @@ export function serveReleaseHistoryOf(
 }
 
 export function findPatchArchive(platform: Platform, identifier: string): string {
-  return findArchive(platform, identifier, (fileName) => fileName.endsWith(PATCH_ARCHIVE_SUFFIX));
+  return findArchive(platform, identifier, "binary-patch");
 }
 
-/** The full archive of a release is stored under its package hash, with no extension. */
+/** The full archive of a release is stored under its full-bundle artifact type. */
 export function findFullArchive(platform: Platform, identifier: string): string {
-  return findArchive(platform, identifier, (fileName) => !fileName.endsWith(PATCH_ARCHIVE_SUFFIX));
+  return findArchive(platform, identifier, "full-bundle");
 }
 
-function findArchive(platform: Platform, identifier: string, matches: (fileName: string) => boolean): string {
+function findArchive(
+  platform: Platform,
+  identifier: string,
+  artifactType: "full-bundle" | "binary-patch",
+): string {
   const bundleDir = path.join(MOCK_DATA_DIR, "bundles", platform, identifier);
-  const fileNames = fs.existsSync(bundleDir) ? fs.readdirSync(bundleDir).filter(matches) : [];
+  const archivePaths = findFiles(bundleDir)
+    .filter((filePath) => path.relative(bundleDir, filePath).split(path.sep).includes(artifactType));
 
-  if (fileNames.length !== 1) {
+  if (archivePaths.length !== 1) {
     throw new Error(
-      `Expected exactly one matching archive in "${bundleDir}", found ${fileNames.length}: [${fileNames.join(", ")}]`,
+      `Expected exactly one ${artifactType} archive in "${bundleDir}", found ${archivePaths.length}: ` +
+      `[${archivePaths.map((filePath) => path.relative(bundleDir, filePath)).join(", ")}]`,
     );
   }
 
-  return path.join(bundleDir, fileNames[0]);
+  return archivePaths[0];
+}
+
+function findFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    return entry.isDirectory() ? findFiles(entryPath) : [entryPath];
+  });
 }
 
 export function readPatchManifest(archivePath: string): BinaryPatchManifest {

--- a/e2e/helpers/download-order.ts
+++ b/e2e/helpers/download-order.ts
@@ -1,5 +1,4 @@
 import { clearRequestLog, getRequestLog } from "../mock-server/server";
-import { PATCH_ARCHIVE_SUFFIX } from "./artifact-storage";
 
 /**
  * Which archive of an update the app asked the mock server for.
@@ -21,7 +20,7 @@ export function startRecordingDownloads(): void {
 export function getDownloadedArchives(): DownloadedArchive[] {
   return getRequestLog()
     .filter((request) => request.method === "GET" && request.url.startsWith("/bundles/"))
-    .map((request) => (request.url.endsWith(PATCH_ARCHIVE_SUFFIX) ? "patch" : "full"));
+    .map((request) => (request.url.includes("/binary-patch/") ? "patch" : "full"));
 }
 
 export function assertDownloadedArchives(scenario: string, expected: DownloadedArchive[]): void {

--- a/e2e/templates/code-push.config.local.ts
+++ b/e2e/templates/code-push.config.local.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This template has environment-specific dependencies.
 // @ts-nocheck
 import {
+  type BundleUploadArtifact,
   CliConfigInterface,
   ReleaseHistoryInterface,
 } from "@bravemobile/react-native-code-push";
@@ -34,26 +36,50 @@ function recordArtifact(entry: Record<string, unknown>) {
   fs.appendFileSync(ARTIFACT_LOG_PATH, `${JSON.stringify(entry)}\n`);
 }
 
+function bundleFileRemotePath(
+  platform: "ios" | "android",
+  identifier: string,
+  artifact: BundleUploadArtifact,
+) {
+  if (artifact.type === "full-bundle") {
+    return `bundles/${platform}/${identifier}/full-bundle/${artifact.packageHash}`;
+  }
+
+  const artifactPath = artifact.type === "asset-diff"
+    ? `asset-diff/${artifact.targetBinaryVersion}/${artifact.packageHash}/${artifact.basePackageHash}`
+    : `binary-patch/${artifact.targetBinaryVersion}/${artifact.packageHash}`;
+
+  return `bundles/${platform}/${identifier}/${artifactPath}`;
+}
+
 const Config: CliConfigInterface = {
   bundleUploader: async (
     source: string,
     platform: "ios" | "android",
     identifier = "staging",
+    artifact,
   ): Promise<{ downloadUrl: string }> => {
-    const fileName = path.basename(source);
-    const destDir = path.join(MOCK_DATA_DIR, "bundles", platform, identifier);
+    if (artifact === undefined) {
+      throw new Error("The release command did not provide bundle artifact metadata.");
+    }
+
+    const remotePath = bundleFileRemotePath(platform, identifier, artifact);
+    const destPath = path.join(MOCK_DATA_DIR, remotePath);
+    const destDir = path.dirname(destPath);
     ensureDir(destDir);
-    const destPath = path.join(destDir, fileName);
     fs.copyFileSync(source, destPath);
 
-    const downloadUrl = `${MOCK_SERVER_HOST}/bundles/${platform}/${identifier}/${fileName}`;
+    const downloadUrl = `${MOCK_SERVER_HOST}/${remotePath}`;
     console.log("Bundle copied to:", destPath);
     console.log("Download URL:", downloadUrl);
     recordArtifact({
       kind: "bundle",
       platform,
       identifier,
-      fileName,
+      artifactType: artifact.type,
+      targetBinaryVersion: artifact.targetBinaryVersion,
+      packageHash: artifact.packageHash,
+      ...(artifact.type === "asset-diff" ? { basePackageHash: artifact.basePackageHash } : {}),
       storedPath: path.relative(MOCK_DATA_DIR, destPath),
       downloadUrl,
     });

--- a/typings/react-native-code-push.d.ts
+++ b/typings/react-native-code-push.d.ts
@@ -634,6 +634,31 @@ declare namespace CodePush {
 export default CodePush;
 
 /**
+ * Identifies the archive passed to `bundleUploader` during a release.
+ *
+ * `targetBinaryVersion` is the value of the release command's `--binary-version` option.
+ * A full bundle's `packageHash` identifies its contents across target binary versions, while
+ * binary patch and asset diff archives need the target binary version to distinguish their contents.
+ * Asset diff archives also identify the released package they were built against.
+ */
+export type BundleUploadArtifact = {
+    targetBinaryVersion: string;
+    packageHash: string;
+} & (
+    | { type: 'full-bundle' }
+    | { type: 'binary-patch' }
+    | { type: 'asset-diff'; basePackageHash: string }
+);
+
+/** Identifies the previously released full archive passed to `bundleDownloader`. */
+export interface BundleDownloadInfo {
+    downloadUrl: string;
+    targetBinaryVersion: string;
+    releaseVersion: ReleaseVersion;
+    packageHash: string;
+}
+
+/**
  * Interface for the config file required for `npx code-push` CLI operation.
  *
  * Please refer to the example code for implementation guidance.
@@ -647,25 +672,15 @@ export interface CliConfigInterface {
      *
      * @param source The relative path of the generated bundle file. (e.g. build/bundleOutput/1087bc338fc45a961c...)
      * @param platform The target platform of the bundle file. This is the string passed when executing the CLI command. ('ios'/'android')
+     * @param artifact Information that identifies the full bundle, binary patch, or asset diff archive. The release command always supplies it; it remains optional so existing callers and three-parameter implementations stay compatible.
      * @return {Promise<{downloadUrl: string}>} An object containing the `downloadUrl` property, which is the URL from which the uploaded bundle file can be downloaded. This URL will be recorded in the release history.
      */
     bundleUploader: (
         source: string,
         platform: "ios" | "android",
         identifier?: string,
+        artifact?: BundleUploadArtifact,
     ) => Promise<{downloadUrl: string}>;
-
-    /**
-     * Downloads a previously released update archive so the release command can compute
-     * asset diffs against it. Receives the `downloadUrl` recorded in the release history and
-     * must resolve with the local path of the downloaded file.
-     * Optional: when absent, releases are published without asset diff archives.
-     */
-    bundleDownloader?: (
-        downloadUrl: string,
-        platform: "ios" | "android",
-        identifier?: string,
-    ) => Promise<{ downloadedFilePath: string }>;
 
     /**
      * Interface that must be implemented to retrieve ReleaseHistory information.
@@ -702,4 +717,19 @@ export interface CliConfigInterface {
         platform: "ios" | "android",
         identifier?: string,
     ) => Promise<void>;
+
+    /**
+     * Downloads a previously released update archive so the release command can compute
+     * asset diffs against it. Receives the `downloadUrl` recorded in the release history and
+     * must resolve with the local path of the downloaded file.
+     * Optional: when absent, releases are published without asset diff archives.
+     *
+     * @param archive Information that identifies the released full archive. The release command
+     * supplies its download URL, target binary version, release version, and package hash together.
+     */
+    bundleDownloader?: (
+        archive: BundleDownloadInfo,
+        platform: "ios" | "android",
+        identifier?: string,
+    ) => Promise<{ downloadedFilePath: string }>;
 }


### PR DESCRIPTION
## Background

Storage configurations only received generated file paths and download URLs. They therefore had to parse CLI-owned artifact names or reverse a URL into a storage key to distinguish full bundles, binary patches, and asset diff archives. The release command already knows that information, so it should pass it to the callbacks directly.

## Changes

- Pass discriminated artifact metadata, including the target binary version and package hashes, to `bundleUploader`.
- Pass released full-bundle metadata to `bundleDownloader`, including the release version needed to identify an asset-diff base without parsing its URL.
- Document the callback contracts and storage-key layout, keeping full bundles shareable across target binary versions while scoping patches and asset diffs to their target binary version.
- Update the CodePushDemoApp, E2E configuration template, helpers, and tests to use the metadata-based contracts. The S3 demo centralizes its shared AWS configuration.

## Verification

- `npm run --workspace cli test -- --watchman=false --runInBand`
- `npm run type:cli`
- `npm run type:e2e`
- `./node_modules/.bin/tsc --noEmit -p Examples/CodePushDemoApp/tsconfig.json`
- `./node_modules/.bin/eslint --no-ignore Examples/CodePushDemoApp/code-push.config.ts Examples/CodePushDemoApp/code-push.config.example.firebase.ts Examples/CodePushDemoApp/code-push.config.example.supabase.ts Examples/CodePushDemoApp/scripts/awsConstants.ts Examples/CodePushDemoApp/scripts/downloadFileFromS3.ts Examples/CodePushDemoApp/scripts/invalidateCloudfrontCache.ts Examples/CodePushDemoApp/scripts/uploadFileToS3.ts`
