### PR TITLE
test: add an iOS unit test suite for the binary patch and asset diff paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,31 @@ Follow these steps to test your modifications to the plugin manually:
 - configure the plugin using the steps in the README.md
 - build and run your app on an emulator or device
 
+## Native unit tests
+
+Both test suites live in this repository and run against the RN0840 example app.
+Sync the library into the example app first:
+
+    cd Examples/RN0840 && npm install
+
+### Android
+
+    cd Examples/RN0840/android && ./gradlew :bravemobile_react-native-code-push:cleanTestDebugUnitTest :bravemobile_react-native-code-push:testDebugUnitTest
+
+The clean task matters: Gradle otherwise reports a stale UP-TO-DATE result.
+
+### iOS
+
+The tests are declared as a `test_spec` of the CodePush pod and read their
+sources from `ios/CodePushTests/` in this checkout, so there is nothing to
+sync for them. Install pods once, then run:
+
+    cd Examples/RN0840/ios && bundle exec pod install
+    xcodebuild test -workspace RN0840.xcworkspace -scheme CodePush \
+      -destination 'platform=iOS Simulator,name=<an available iPhone>'
+
+Neither suite runs in CI.
+
 ## Test
 
 ### Environment setup

--- a/CodePush.podspec
+++ b/CodePush.podspec
@@ -36,6 +36,11 @@ Pod::Spec.new do |s|
   ]
   s.public_header_files = ['ios/CodePush/CodePush.h']
 
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'ios/CodePushTests/**/*.{h,m}'
+    test_spec.resources = 'cli/fixtures/binary-patch/*'
+  end
+
   binary_patch_header_search_paths = '"$(PODS_TARGET_SRCROOT)/cpp/binarypatch" "$(PODS_TARGET_SRCROOT)/cpp/binarypatch/vendor/HDiffPatch" "$(PODS_TARGET_SRCROOT)/cpp/binarypatch/vendor/zstd"'
   # ZSTD_DISABLE_ASM: the assembly fast path is intentionally not vendored.
   # _IS_USED_MULTITHREAD=0: patches are applied on the thread that downloads them.

--- a/Examples/RN0840/ios/Podfile
+++ b/Examples/RN0840/ios/Podfile
@@ -15,6 +15,11 @@ if linkage != nil
 end
 
 target 'RN0840' do
+  # Activates the CodePush pod's unit tests. Autolinking skips a pod that is
+  # already declared, so this replaces the generated declaration and points it
+  # at the repository checkout, where the test sources live.
+  pod 'CodePush', :path => '../../..', :testspecs => ['Tests']
+
   config = use_native_modules!
 
   use_react_native!(

--- a/Examples/RN0840/ios/Podfile.lock
+++ b/Examples/RN0840/ios/Podfile.lock
@@ -1,5 +1,12 @@
 PODS:
-  - CodePush (13.0.0):
+  - CodePush (13.1.0.4):
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - SSZipArchive (~> 2.5.5)
+  - CodePush/Tests (13.1.0.4):
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -1865,7 +1872,8 @@ PODS:
   - Yoga (0.0.0)
 
 DEPENDENCIES:
-  - "CodePush (from `../node_modules/@bravemobile/react-native-code-push`)"
+  - CodePush (from `../../..`)
+  - CodePush/Tests (from `../../..`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -1948,7 +1956,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   CodePush:
-    :path: "../node_modules/@bravemobile/react-native-code-push"
+    :path: "../../.."
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   hermes-engine:
@@ -2100,7 +2108,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  CodePush: 43cb436504305ff35f9c9a0dae804d82bbe05294
+  CodePush: f3b475f11ba84c010c83a1be5510b69ef3a53a1d
   FBLazyVector: c12d2108050e27952983d565a232f6f7b1ad5e69
   hermes-engine: 29cff50d2e023efa10c2207eca3a1446cfd31bdc
   RCTDeprecation: 3280799c14232a56e5a44f92981a8ee33bc69fd9
@@ -2177,6 +2185,6 @@ SPEC CHECKSUMS:
   SSZipArchive: c69881e8ac5521f0e622291387add5f60f30f3c4
   Yoga: 772166513f9cd2d61a6251d0dacbbfaa5b537479
 
-PODFILE CHECKSUM: 9c5003cc697b12834ac65a6b886dda6fff0282b1
+PODFILE CHECKSUM: d2d9cd5e86b8d498917d5daa7ac9c5a39736b92f
 
 COCOAPODS: 1.15.2

--- a/ios/CodePushTests/CodePushBinaryPatchTests.m
+++ b/ios/CodePushTests/CodePushBinaryPatchTests.m
@@ -1,3 +1,15 @@
+/*
+ * Two of the scenarios the applier of the other platform is tested against have no
+ * counterpart among the restore scenarios below:
+ *
+ *   - a missing native library. The applier is compiled into the app binary here, so
+ *     there is no library that could fail to load.
+ *   - a restored bundle of another size. The applier compares the size the manifest
+ *     promises against the patch header before it writes a byte, so a size that does not
+ *     match is refused as a failed apply long before the restored bundle is verified.
+ *     testReportsAFailedApplyWhenTheManifestPromisesAnotherSize covers it in that place.
+ */
+
 #import <XCTest/XCTest.h>
 #import "CodePush.h"
 #import "CodePushBinaryPatch.h"
@@ -13,6 +25,9 @@
 @end
 
 static NSString *const AssetDiffManifestFileName = @"hotcodepush.json";
+static NSString *const BinaryPatchManifestFileName = @"codepush-binary-patch.json";
+static NSString *const BinaryPatchFileName = @"main.jsbundle.patch";
+static NSString *const BundleFileName = @"main.jsbundle";
 
 @interface CodePushBinaryPatchTests : XCTestCase
 @property (nonatomic, copy) NSString *root;
@@ -122,6 +137,276 @@ static NSString *const AssetDiffManifestFileName = @"hotcodepush.json";
 - (void)testResolvesAManifestPathThatWalksBackInsideTheFolder {
     NSString *bundle = [CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"assets/../main.jsbundle"];
     XCTAssertEqualObjects([bundle stringByStandardizingPath], [self rootPath:@"main.jsbundle"]);
+}
+
+@end
+
+/*
+ * The restore itself, against the patch the CLI produced from the two bundle fixtures.
+ * Nothing here stands in for the applier: every scenario runs the real one.
+ *
+ * These own their temp root rather than sharing the one above, because the shape tests
+ * read the whole of theirs and an archive laid out beside them would change what they see.
+ */
+@interface CodePushBinaryPatchRestoreTests : XCTestCase
+@property (nonatomic, copy) NSString *root;
+@property (nonatomic, copy) NSString *contentsFolder;
+@property (nonatomic, copy) NSString *workingFolder;
+@property (nonatomic, copy) NSString *baseBundlePath;
+@property (nonatomic, strong) NSMutableDictionary *manifest;
+@end
+
+@implementation CodePushBinaryPatchRestoreTests
+
+/* A patch archive as it arrives, beside the bundle the patch was computed against. Each
+ * scenario below changes one thing about that. */
+- (void)setUp {
+    [super setUp];
+    self.root = CPTestMakeTempDirectory();
+    self.contentsFolder = [self.root stringByAppendingPathComponent:@"contents"];
+    self.workingFolder = [self.root stringByAppendingPathComponent:@"working"];
+    self.baseBundlePath = [self.root stringByAppendingPathComponent:@"base.bundle"];
+    CPTestWriteFile(self.baseBundlePath, CPTestFixture(@"base.bundle"));
+    CPTestWriteFile([self contentsPath:BinaryPatchFileName], CPTestFixture(@"update.patch"));
+    self.manifest = CPTestValidPatchManifest();
+    [self writePatchManifest:self.manifest];
+}
+
+- (void)tearDown {
+    [[NSFileManager defaultManager] removeItemAtPath:self.root error:nil];
+    [super tearDown];
+}
+
+#pragma mark - Helpers
+
+- (NSString *)contentsPath:(NSString *)relativePath {
+    return [self.contentsFolder stringByAppendingPathComponent:relativePath];
+}
+
+- (BOOL)fileExists:(NSString *)path {
+    return [[NSFileManager defaultManager] fileExistsAtPath:path];
+}
+
+- (void)writePatchManifest:(NSDictionary *)manifest {
+    NSData *json = [NSJSONSerialization dataWithJSONObject:manifest options:kNilOptions error:nil];
+    CPTestWriteFile([self contentsPath:BinaryPatchManifestFileName], json);
+}
+
+/** Rewrites the manifest with one of its values replaced. */
+- (void)writePatchManifestWithValue:(id)value forKey:(NSString *)key {
+    self.manifest[key] = value;
+    [self writePatchManifest:self.manifest];
+}
+
+/** Moves the archive's files into a wrapper directory, as an archive carrying one arrives. */
+- (NSString *)wrapArchiveContentsInDirectory:(NSString *)name {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *wrapper = [self contentsPath:name];
+    NSError *error = nil;
+    XCTAssertTrue([fileManager createDirectoryAtPath:wrapper
+                         withIntermediateDirectories:YES
+                                          attributes:nil
+                                               error:&error], @"%@", error);
+    for (NSString *file in @[BinaryPatchFileName, BinaryPatchManifestFileName]) {
+        XCTAssertTrue([fileManager moveItemAtPath:[self contentsPath:file]
+                                           toPath:[wrapper stringByAppendingPathComponent:file]
+                                            error:&error], @"%@", error);
+    }
+    return wrapper;
+}
+
+- (void)removeFileAtPath:(NSString *)path {
+    NSError *error = nil;
+    XCTAssertTrue([[NSFileManager defaultManager] removeItemAtPath:path error:&error], @"%@", error);
+}
+
+- (BOOL)restoreBundleWithFailureReason:(NSString **)failureReason {
+    return [CodePushBinaryPatch restoreBundleInUnzippedFolder:self.contentsFolder
+                                                workingFolder:self.workingFolder
+                                                baseBundleURL:[NSURL fileURLWithPath:self.baseBundlePath]
+                                                failureReason:failureReason];
+}
+
+- (void)assertRestoreSucceeds {
+    NSString *reason = nil;
+    XCTAssertTrue([self restoreBundleWithFailureReason:&reason], @"the restore failed with %@", reason);
+    XCTAssertFalse([self fileExists:self.workingFolder],
+                   @"the working directory outlived the patch attempt");
+}
+
+- (void)assertFailureReason:(NSString *)expected {
+    NSString *reason = nil;
+    XCTAssertFalse([self restoreBundleWithFailureReason:&reason]);
+    XCTAssertEqualObjects(reason, expected);
+    XCTAssertFalse([self fileExists:self.workingFolder],
+                   @"the working directory outlived the patch attempt");
+}
+
+/* Hashed rather than compared as data, so that a mismatch reports two hashes instead of
+ * two bundles. */
+- (void)assertTargetBundleAtPath:(NSString *)path {
+    NSData *restored = [NSData dataWithContentsOfFile:path];
+    XCTAssertNotNil(restored, @"no bundle was restored at %@", path);
+    XCTAssertEqualObjects(CPTestSha256Hex(restored), CPTestSha256Hex(CPTestFixture(@"target.bundle")),
+                          @"the restored bundle is not the target bundle");
+}
+
+#pragma mark - Restoring
+
+- (void)testAppliesAPatchAndLeavesTheContentsOfAFullArchiveBehind {
+    [self assertRestoreSucceeds];
+    [self assertTargetBundleAtPath:[self contentsPath:BundleFileName]];
+    XCTAssertFalse([self fileExists:[self contentsPath:BinaryPatchFileName]],
+                   @"the patch is still among the update contents");
+    XCTAssertFalse([self fileExists:[self contentsPath:BinaryPatchManifestFileName]],
+                   @"the patch manifest is still among the update contents");
+}
+
+- (void)testAppliesAPatchThatSitsInTheArchivesOwnRootDirectory {
+    NSString *wrapper = [self wrapArchiveContentsInDirectory:@"CodePush"];
+    [self assertRestoreSucceeds];
+    [self assertTargetBundleAtPath:[wrapper stringByAppendingPathComponent:BundleFileName]];
+}
+
+- (void)testRestoresTheBundleWhenTheDiffManifestSitsBesideTheContentsDirectory {
+    NSString *wrapper = [self wrapArchiveContentsInDirectory:@"CodePush"];
+    NSString *assetPath = [wrapper stringByAppendingPathComponent:@"assets/logo.png"];
+    CPTestWriteFile(assetPath, [@"an asset the archive carries" dataUsingEncoding:NSUTF8StringEncoding]);
+    NSString *diffManifestPath = [self contentsPath:AssetDiffManifestFileName];
+    CPTestWriteFile(diffManifestPath, [@"{\"deletedFiles\":[]}" dataUsingEncoding:NSUTF8StringEncoding]);
+
+    [self assertRestoreSucceeds];
+    [self assertTargetBundleAtPath:[wrapper stringByAppendingPathComponent:BundleFileName]];
+    XCTAssertTrue([self fileExists:diffManifestPath], @"the asset diff manifest went with the patch");
+    XCTAssertTrue([self fileExists:assetPath], @"an asset of the archive went with the patch");
+}
+
+- (void)testKeepsARootHoldingLooseFilesBesidesTheDiffManifestAsItsOwnContentsRoot {
+    CPTestWriteFile([self contentsPath:AssetDiffManifestFileName],
+                    [@"{\"deletedFiles\":[]}" dataUsingEncoding:NSUTF8StringEncoding]);
+    [self assertRestoreSucceeds];
+    [self assertTargetBundleAtPath:[self contentsPath:BundleFileName]];
+}
+
+- (void)testRemovesWhatAnInterruptedAttemptLeftInTheWorkingDirectory {
+    CPTestWriteFile([self.workingFolder stringByAppendingPathComponent:@"target.bundle"],
+                    [@"half of an earlier restore" dataUsingEncoding:NSUTF8StringEncoding]);
+    [self assertRestoreSucceeds];
+    [self assertTargetBundleAtPath:[self contentsPath:BundleFileName]];
+}
+
+#pragma mark - Refusing the manifest
+
+- (void)testReportsAnInvalidManifestWhenThereIsNone {
+    [self removeFileAtPath:[self contentsPath:BinaryPatchManifestFileName]];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnInvalidManifestWhenItIsNotJson {
+    CPTestWriteFile([self contentsPath:BinaryPatchManifestFileName],
+                    [@"not json at all" dataUsingEncoding:NSUTF8StringEncoding]);
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnUnsupportedFormatForAnotherFormatVersion {
+    [self writePatchManifestWithValue:@2 forKey:@"formatVersion"];
+    [self assertFailureReason:CodePushBinaryPatchReasonUnsupportedFormat];
+}
+
+- (void)testReportsAnUnsupportedFormatForAnotherAlgorithm {
+    [self writePatchManifestWithValue:@"bsdiff-bz2" forKey:@"algorithm"];
+    [self assertFailureReason:CodePushBinaryPatchReasonUnsupportedFormat];
+}
+
+- (void)testReportsAnInvalidManifestWhenTheBundlePathLeavesTheArchive {
+    [self writePatchManifestWithValue:@"../main.jsbundle" forKey:@"bundlePath"];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+    XCTAssertFalse([self fileExists:[self.root stringByAppendingPathComponent:BundleFileName]],
+                   @"a bundle was restored outside the archive");
+}
+
+- (void)testReportsAnInvalidManifestWhenThePatchPathLeavesTheArchive {
+    CPTestWriteFile([self.root stringByAppendingPathComponent:BinaryPatchFileName],
+                    CPTestFixture(@"update.patch"));
+    [self writePatchManifestWithValue:@"../main.jsbundle.patch" forKey:@"patchFile"];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnInvalidManifestWhenTheBundlePathIsAbsolute {
+    [self writePatchManifestWithValue:[self contentsPath:BundleFileName] forKey:@"bundlePath"];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnInvalidManifestWhenTheArchiveHasNoPatchFile {
+    [self removeFileAtPath:[self contentsPath:BinaryPatchFileName]];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnInvalidManifestWhenTheTargetSizeIsEmpty {
+    [self writePatchManifestWithValue:@0 forKey:@"targetBundleSize"];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+- (void)testReportsAnInvalidManifestWhenTheTargetSizeIsBeyondTheLimit {
+    [self writePatchManifestWithValue:@(128LL * 1024 * 1024 + 1) forKey:@"targetBundleSize"];
+    [self assertFailureReason:CodePushBinaryPatchReasonInvalidManifest];
+}
+
+#pragma mark - Refusing the base bundle
+
+- (void)testReportsAnUnavailableBaseBundleWhenTheBinaryBundleCannotBeRead {
+    self.baseBundlePath = [self.root stringByAppendingPathComponent:@"no-such.bundle"];
+    [self assertFailureReason:CodePushBinaryPatchReasonBaseBundleUnavailable];
+}
+
+- (void)testReportsABaseHashMismatchWhenTheBinaryHoldsAnotherBundle {
+    CPTestWriteFile(self.baseBundlePath, [@"another bundle entirely" dataUsingEncoding:NSUTF8StringEncoding]);
+    [self assertFailureReason:CodePushBinaryPatchReasonBaseHashMismatch];
+    XCTAssertFalse([self fileExists:[self contentsPath:BundleFileName]],
+                   @"a bundle was restored from a base bundle that was never checked");
+}
+
+#pragma mark - Refusing the patch
+
+- (void)testReportsAnUnsupportedFormatWhenThePatchUsesAnotherCodec {
+    NSMutableData *patch = [CPTestFixture(@"update.patch") mutableCopy];
+    // The header reads "HDIFF13&zstd\0...". A codec name of the same length keeps the
+    // header readable, so all that is left to refuse is the codec itself.
+    [patch replaceBytesInRange:NSMakeRange(8, 4) withBytes:"lzma" length:4];
+    CPTestWriteFile([self contentsPath:BinaryPatchFileName], patch);
+    [self assertFailureReason:CodePushBinaryPatchReasonUnsupportedFormat];
+}
+
+- (void)testReportsAFailedApplyWhenThePatchHeaderIsCorrupt {
+    CPTestWriteFile([self contentsPath:BinaryPatchFileName],
+                    [@"the difference between the two" dataUsingEncoding:NSUTF8StringEncoding]);
+    [self assertFailureReason:CodePushBinaryPatchReasonPatchApplyFailed];
+    XCTAssertFalse([self fileExists:[self contentsPath:BundleFileName]],
+                   @"a bundle was restored from a patch that could not be read");
+}
+
+- (void)testReportsAFailedApplyWhenTheManifestPromisesAnotherSize {
+    long long targetBundleSize = [self.manifest[@"targetBundleSize"] longLongValue];
+    [self writePatchManifestWithValue:@(targetBundleSize - 1) forKey:@"targetBundleSize"];
+    [self assertFailureReason:CodePushBinaryPatchReasonPatchApplyFailed];
+}
+
+#pragma mark - Refusing the restored bundle
+
+- (void)testReportsAFailedVerificationWhenTheRestoredBundleHasAnotherContent {
+    NSString *targetBundleHash = self.manifest[@"targetBundleHash"];
+    NSString *firstCharacter = [targetBundleHash substringToIndex:1];
+    [self writePatchManifestWithValue:[targetBundleHash stringByReplacingCharactersInRange:NSMakeRange(0, 1)
+                                                                               withString:[firstCharacter isEqualToString:@"a"] ? @"b" : @"a"]
+                               forKey:@"targetBundleHash"];
+
+    [self assertFailureReason:CodePushBinaryPatchReasonTargetVerificationFailed];
+    XCTAssertFalse([self fileExists:[self contentsPath:BundleFileName]],
+                   @"a bundle that failed verification was put among the update contents");
+    XCTAssertTrue([self fileExists:[self contentsPath:BinaryPatchFileName]],
+                  @"the patch was taken away from contents that were never restored");
+    XCTAssertTrue([self fileExists:[self contentsPath:BinaryPatchManifestFileName]],
+                  @"the patch manifest was taken away from contents that were never restored");
 }
 
 @end

--- a/ios/CodePushTests/CodePushBinaryPatchTests.m
+++ b/ios/CodePushTests/CodePushBinaryPatchTests.m
@@ -11,7 +11,6 @@
  */
 
 #import <XCTest/XCTest.h>
-#import "CodePush.h"
 #import "CodePushBinaryPatch.h"
 #import "CodePushTestHelpers.h"
 

--- a/ios/CodePushTests/CodePushBinaryPatchTests.m
+++ b/ios/CodePushTests/CodePushBinaryPatchTests.m
@@ -1,0 +1,30 @@
+#import <XCTest/XCTest.h>
+#import "CodePush.h"
+#import "CodePushBinaryPatch.h"
+
+/*
+ * The resolution and guard methods are internal to their classes. Objective-C
+ * dispatch finds them at runtime, so declaring them here is all a test needs.
+ */
+@interface CodePushBinaryPatch (TestAccess)
++ (NSString *)contentsFolderInUnzippedFolder:(NSString *)unzippedFolderPath;
++ (NSString *)pathInsideFolder:(NSString *)folderPath relativePath:(NSString *)relativePath;
+@end
+
+@interface CodePushBinaryPatchTests : XCTestCase
+@end
+
+@implementation CodePushBinaryPatchTests
+
+- (void)testResolvesAnEmptyFolderAsItsOwnContentsRoot {
+    NSString *folder = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    NSError *error = nil;
+    XCTAssertTrue([[NSFileManager defaultManager] createDirectoryAtPath:folder
+                                            withIntermediateDirectories:YES
+                                                             attributes:nil
+                                                                  error:&error]);
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:folder], folder);
+    [[NSFileManager defaultManager] removeItemAtPath:folder error:nil];
+}
+
+@end

--- a/ios/CodePushTests/CodePushBinaryPatchTests.m
+++ b/ios/CodePushTests/CodePushBinaryPatchTests.m
@@ -1,6 +1,7 @@
 #import <XCTest/XCTest.h>
 #import "CodePush.h"
 #import "CodePushBinaryPatch.h"
+#import "CodePushTestHelpers.h"
 
 /*
  * The resolution and guard methods are internal to their classes. Objective-C
@@ -11,20 +12,116 @@
 + (NSString *)pathInsideFolder:(NSString *)folderPath relativePath:(NSString *)relativePath;
 @end
 
+static NSString *const AssetDiffManifestFileName = @"hotcodepush.json";
+
 @interface CodePushBinaryPatchTests : XCTestCase
+@property (nonatomic, copy) NSString *root;
 @end
 
 @implementation CodePushBinaryPatchTests
 
-- (void)testResolvesAnEmptyFolderAsItsOwnContentsRoot {
-    NSString *folder = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+- (void)setUp {
+    [super setUp];
+    self.root = CPTestMakeTempDirectory();
+}
+
+- (void)tearDown {
+    [[NSFileManager defaultManager] removeItemAtPath:self.root error:nil];
+    [super tearDown];
+}
+
+- (NSString *)makeFile:(NSString *)name {
+    NSString *path = [self.root stringByAppendingPathComponent:name];
+    CPTestWriteFile(path, [NSData dataWithBytes:"x" length:1]);
+    return path;
+}
+
+- (NSString *)makeDirectory:(NSString *)name {
+    NSString *path = [self.root stringByAppendingPathComponent:name];
     NSError *error = nil;
-    XCTAssertTrue([[NSFileManager defaultManager] createDirectoryAtPath:folder
+    XCTAssertTrue([[NSFileManager defaultManager] createDirectoryAtPath:path
                                             withIntermediateDirectories:YES
                                                              attributes:nil
-                                                                  error:&error]);
-    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:folder], folder);
-    [[NSFileManager defaultManager] removeItemAtPath:folder error:nil];
+                                                                  error:&error],
+                  @"%@", error);
+    return path;
+}
+
+/* The simulator reaches its temp folder through a symlink, so both sides standardize. */
+- (NSString *)rootPath:(NSString *)relativePath {
+    return [[self.root stringByAppendingPathComponent:relativePath] stringByStandardizingPath];
+}
+
+#pragma mark - Archive shape
+
+- (void)testResolvesAnEmptyFolderAsItsOwnContentsRoot {
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+- (void)testResolvesAFolderOfOneFileAsItsOwnContentsRoot {
+    [self makeFile:@"main.jsbundle"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+- (void)testUnwrapsTheSingleDirectoryInsideTheFolder {
+    NSString *wrapper = [self makeDirectory:@"CodePush"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], wrapper);
+}
+
+- (void)testResolvesAFolderOfTwoDirectoriesAsItsOwnContentsRoot {
+    [self makeDirectory:@"CodePush"];
+    [self makeDirectory:@"assets"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+- (void)testResolvesAFolderOfADirectoryAndAFileAsItsOwnContentsRoot {
+    [self makeDirectory:@"assets"];
+    [self makeFile:@"main.jsbundle"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+- (void)testResolvesAFolderOfOnlyTheAssetDiffManifestAsItsOwnContentsRoot {
+    [self makeFile:AssetDiffManifestFileName];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+- (void)testUnwrapsTheSingleDirectoryBesideTheAssetDiffManifest {
+    CPTestWriteFile([self.root stringByAppendingPathComponent:AssetDiffManifestFileName],
+                    [@"{\"deletedFiles\":[]}" dataUsingEncoding:NSUTF8StringEncoding]);
+    NSString *wrapper = [self makeDirectory:@"CodePush"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], wrapper);
+}
+
+- (void)testResolvesAFolderOfTheAssetDiffManifestAndAFileAsItsOwnContentsRoot {
+    [self makeFile:AssetDiffManifestFileName];
+    [self makeFile:@"main.jsbundle"];
+    XCTAssertEqualObjects([CodePushBinaryPatch contentsFolderInUnzippedFolder:self.root], self.root);
+}
+
+#pragma mark - Path guard
+
+- (void)testRefusesAManifestPathThatLeavesTheFolder {
+    XCTAssertNil([CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"../outside.txt"]);
+    XCTAssertNil([CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"a/../../outside.txt"]);
+    XCTAssertNil([CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"/etc/passwd"]);
+    XCTAssertNil([CodePushBinaryPatch pathInsideFolder:self.root relativePath:@""]);
+}
+
+- (void)testRefusesAMissingManifestPath {
+    XCTAssertNil([CodePushBinaryPatch pathInsideFolder:self.root relativePath:nil]);
+}
+
+- (void)testResolvesAManifestPathAgainstTheFolder {
+    NSString *bundle = [CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"main.jsbundle"];
+    XCTAssertEqualObjects([bundle stringByStandardizingPath], [self rootPath:@"main.jsbundle"]);
+
+    NSString *asset = [CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"assets/img/logo.png"];
+    XCTAssertEqualObjects([asset stringByStandardizingPath], [self rootPath:@"assets/img/logo.png"]);
+}
+
+- (void)testResolvesAManifestPathThatWalksBackInsideTheFolder {
+    NSString *bundle = [CodePushBinaryPatch pathInsideFolder:self.root relativePath:@"assets/../main.jsbundle"];
+    XCTAssertEqualObjects([bundle stringByStandardizingPath], [self rootPath:@"main.jsbundle"]);
 }
 
 @end

--- a/ios/CodePushTests/CodePushPackageTests.m
+++ b/ios/CodePushTests/CodePushPackageTests.m
@@ -265,9 +265,25 @@ static NSData *CPTestBytes(NSString *text) {
     XCTAssertGreaterThanOrEqual([result[@"applyDurationMs"] doubleValue], 0, @"the attempt is timed");
 }
 
+/* Where a patch attempt does its work, which no attempt may leave behind. */
+- (NSString *)binaryPatchFolder {
+    return [[CodePushPackage getCodePushPath] stringByAppendingPathComponent:@"binary-patch"];
+}
+
+/*
+ * What an attempt that was killed halfway through leaves in the working directory. Only the
+ * download clears this on a patch URL that never reaches the applier, so planting it is what
+ * gives the assertion below something of the download's own to observe.
+ */
+- (void)plantAbandonedBinaryPatchWorkingDirectory {
+    NSString *leftover = [[self binaryPatchFolder] stringByAppendingPathComponent:@"leftover.txt"];
+    CPTestWriteFile(leftover, CPTestBytes(@"half of an earlier restore"));
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:leftover],
+                  @"the abandoned working directory was not planted");
+}
+
 - (void)assertBinaryPatchFolderRemoved {
-    NSString *workingFolder = [[CodePushPackage getCodePushPath] stringByAppendingPathComponent:@"binary-patch"];
-    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:workingFolder],
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:[self binaryPatchFolder]],
                    @"the working directory outlived the patch attempt");
 }
 
@@ -528,8 +544,13 @@ static NSData *CPTestBytes(NSString *text) {
         @"binaryPatchDownloadUrl": [self serveArchive:[self stagePatchArchiveContents] named:@"patch.zip"],
     } error:&error];
     XCTAssertNil(error);
+    // A patch that installed leaves nothing of its attempt behind. The applier empties its own
+    // working directory on the way out, so what this pins is the outcome and not who reached it.
     [self assertBinaryPatchFolderRemoved];
 
+    // A patch URL that never serves an archive is refused before the applier is ever called, so
+    // whatever an earlier attempt abandoned there is the download's alone to clear up.
+    [self plantAbandonedBinaryPatchWorkingDirectory];
     [self downloadPackage:@{
         @"packageHash": packageHash,
         @"downloadUrl": fullUrl,

--- a/ios/CodePushTests/CodePushPackageTests.m
+++ b/ios/CodePushTests/CodePushPackageTests.m
@@ -1,0 +1,565 @@
+/*
+ * Downloading an update's archive and installing what comes out of it.
+ *
+ * These drive the whole pipeline - download, unzip, restore, merge, folder hash, metadata -
+ * against archives served from disk, with only the two seams that reach into the app binary
+ * replaced. The wiring between those steps is where an archive that is not what it claims
+ * has to be caught, so nothing in between stands in for the real thing.
+ */
+
+#import <XCTest/XCTest.h>
+#import "CodePush.h"
+#import "CodePushBinaryPatch.h"
+#import "CodePushTestHelpers.h"
+
+/*
+ * The package's path guard and its root on disk are internal to the class. Objective-C
+ * dispatch finds them at runtime, so declaring them here is all a test needs.
+ */
+@interface CodePushPackage (TestAccess)
++ (NSString *)pathInsideFolder:(NSString *)folderPath relativePath:(NSString *)relativePath;
++ (NSString *)getCodePushPath;
+@end
+
+static NSString *const ExpectedBundleFileName = @"main.jsbundle";
+/* The metadata the install writes last, which is not part of the contents the hash is for. */
+static NSString *const UpdateMetadataFileName = @"app.json";
+
+static NSData *CPTestBytes(NSString *text) {
+    return [text dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@interface CodePushPackageTests : XCTestCase
+@property (nonatomic, copy) NSString *servingFolder;   // the archives, served over file://
+@property (nonatomic, copy) NSString *binaryFolder;    // what the app binary ships with
+@property (nonatomic, strong) NSMutableArray *progressEvents;
+@property (nonatomic, strong) NSMutableArray<NSString *> *temporaryFolders;
+@property (nonatomic) IMP originalBinaryBundleURL;
+@property (nonatomic) IMP originalBundleAssetsPath;
+@end
+
+@implementation CodePushPackageTests
+
+- (void)setUp {
+    [super setUp];
+    [CodePush setUsingTestConfiguration:YES];
+    [CodePushPackage clearUpdates];
+    self.temporaryFolders = [NSMutableArray array];
+    self.servingFolder = [self makeTemporaryFolder];
+    self.progressEvents = [NSMutableArray array];
+
+    // The bundle that shipped inside the binary is the one the patch fixture was computed
+    // against, and the assets beside it are what a diff with nothing installed falls back on.
+    self.binaryFolder = [self makeTemporaryFolder];
+    CPTestWriteFile([self.binaryFolder stringByAppendingPathComponent:ExpectedBundleFileName],
+                    CPTestFixture(@"base.bundle"));
+    CPTestWriteFile([self.binaryFolder stringByAppendingPathComponent:@"assets/binary.png"],
+                    CPTestBytes(@"an asset that shipped inside the binary"));
+
+    NSURL *bundleURL = [NSURL fileURLWithPath:[self.binaryFolder stringByAppendingPathComponent:ExpectedBundleFileName]];
+    NSString *assetsPath = [self.binaryFolder stringByAppendingPathComponent:@"assets"];
+    self.originalBinaryBundleURL = CPTestReplaceClassMethod([CodePush class], @selector(binaryBundleURL),
+                                                            ^NSURL *(id self) { return bundleURL; });
+    self.originalBundleAssetsPath = CPTestReplaceClassMethod([CodePush class], @selector(bundleAssetsPath),
+                                                             ^NSString *(id self) { return assetsPath; });
+}
+
+- (void)tearDown {
+    CPTestRestoreClassMethod([CodePush class], @selector(binaryBundleURL), self.originalBinaryBundleURL);
+    CPTestRestoreClassMethod([CodePush class], @selector(bundleAssetsPath), self.originalBundleAssetsPath);
+    [CodePushPackage clearUpdates];
+    [CodePush setUsingTestConfiguration:NO];
+    for (NSString *folder in self.temporaryFolders) {
+        [[NSFileManager defaultManager] removeItemAtPath:folder error:nil];
+    }
+    [super tearDown];
+}
+
+#pragma mark - Running a download
+
+/* Every folder a scenario stages, so a run leaves nothing of itself behind. */
+- (NSString *)makeTemporaryFolder {
+    NSString *folder = CPTestMakeTempDirectory();
+    [self.temporaryFolders addObject:folder];
+    return folder;
+}
+
+/* Zips a staged folder into the serving folder and returns the URL it is served from. */
+- (NSString *)serveArchive:(NSString *)stagingFolder named:(NSString *)name {
+    NSString *zipPath = [self.servingFolder stringByAppendingPathComponent:name];
+    XCTAssertTrue(CPTestZipFolderContents(stagingFolder, zipPath), @"%@ could not be zipped", stagingFolder);
+    return [[NSURL fileURLWithPath:zipPath] absoluteString];
+}
+
+/* The URL of a file served as it is, which is how an archive that is not one arrives. */
+- (NSString *)serveBytes:(NSData *)body named:(NSString *)name {
+    NSString *path = [self.servingFolder stringByAppendingPathComponent:name];
+    CPTestWriteFile(path, body);
+    return [[NSURL fileURLWithPath:path] absoluteString];
+}
+
+/* The URL of a file the serving folder does not hold, which no download can complete. */
+- (NSString *)urlOfMissingFileNamed:(NSString *)name {
+    return [[NSURL fileURLWithPath:[self.servingFolder stringByAppendingPathComponent:name]] absoluteString];
+}
+
+/* Runs a download to its end and hands back what it reported about the patch attempt. */
+- (NSDictionary *)downloadPackage:(NSDictionary *)updatePackage error:(NSError **)outError {
+    dispatch_queue_t queue = dispatch_queue_create("codepush.test.download", DISPATCH_QUEUE_SERIAL);
+    XCTestExpectation *finished = [self expectationWithDescription:@"download finished"];
+    __block NSDictionary *patchResult = nil;
+    __block NSError *failure = nil;
+    // The callbacks all arrive on the serial queue above, so the events they record are
+    // written there and only read once the wait below has returned.
+    NSMutableArray *events = self.progressEvents;
+    [CodePushPackage downloadPackage:updatePackage
+              expectedBundleFileName:ExpectedBundleFileName
+                      operationQueue:queue
+                    progressCallback:^(long long expected, long long received) {
+                        [events addObject:@[@(expected), @(received)]];
+                    }
+                        doneCallback:^(NSDictionary *binaryPatchResult) {
+                            patchResult = binaryPatchResult;
+                            [finished fulfill];
+                        }
+                        failCallback:^(NSError *error) {
+                            failure = error;
+                            [finished fulfill];
+                        }];
+    [self waitForExpectations:@[finished] timeout:60];
+    if (outError != NULL) { *outError = failure; }
+    return patchResult;
+}
+
+/*
+ * Downloads an update in full and makes it the current package, which is what the asset
+ * diff of a later release is merged into.
+ */
+- (NSString *)installPackageWithContents:(NSString *)stagingFolder {
+    NSString *packageHash = CPTestFolderHash(stagingFolder);
+    NSError *error = nil;
+    [self downloadPackage:@{ @"packageHash": packageHash,
+                             @"downloadUrl": [self serveArchive:stagingFolder named:@"installed.zip"] }
+                    error:&error];
+    XCTAssertNil(error);
+    XCTAssertTrue([CodePushPackage installPackage:@{ @"packageHash": packageHash }
+                              removePendingUpdate:NO
+                                            error:&error]);
+    XCTAssertNil(error);
+    return packageHash;
+}
+
+#pragma mark - Archive staging
+
+/* Writes the entries of an archive - or of the update they add up to - into a folder. */
+- (NSString *)stageContents:(NSDictionary<NSString *, NSData *> *)contents {
+    NSString *staging = [self makeTemporaryFolder];
+    for (NSString *relativePath in contents) {
+        CPTestWriteFile([staging stringByAppendingPathComponent:relativePath], contents[relativePath]);
+    }
+    return staging;
+}
+
+- (NSData *)patchManifest {
+    return [NSJSONSerialization dataWithJSONObject:CPTestValidPatchManifest()
+                                           options:kNilOptions
+                                             error:nil];
+}
+
+/*
+ * The update's full archive, which is also the contents every archive of it has to add up
+ * to and so the folder the package hash is computed over.
+ */
+- (NSString *)stageFullArchiveContents {
+    return [self stageContents:@{
+        @"CodePush/main.jsbundle": CPTestFixture(@"target.bundle"),
+        @"CodePush/assets/logo.png": CPTestBytes(@"an image the update ships with"),
+    }];
+}
+
+/* The same update as a patch archive: the bundle replaced by a patch of it and a manifest. */
+- (NSString *)stagePatchArchiveContents {
+    return [self stageContents:@{
+        @"CodePush/codepush-binary-patch.json": [self patchManifest],
+        @"CodePush/main.jsbundle.patch": CPTestFixture(@"update.patch"),
+        @"CodePush/assets/logo.png": CPTestBytes(@"an image the update ships with"),
+    }];
+}
+
+/* The full archive of the release that is installed when the asset diff arrives. */
+- (NSString *)stageInstalledArchiveContents {
+    return [self stageContents:@{
+        @"CodePush/main.jsbundle": CPTestBytes(@"the bundle of the update already installed"),
+        @"CodePush/assets/logo.png": CPTestBytes(@"an image the update ships with"),
+        @"CodePush/assets/legacy.png": CPTestBytes(@"an image the newer update leaves behind"),
+    }];
+}
+
+/*
+ * An asset diff archive: the patch archive carrying only the assets the update changes, plus
+ * the manifest of the files to delete at the archive root, beside the contents directory the
+ * manifest's paths are relative to. An asset the installed package already holds unchanged is
+ * not shipped at all - the client copies it over.
+ */
+- (NSString *)stageAssetDiffArchiveContentsDeleting:(NSArray<NSString *> *)deletedFiles {
+    return [self stageContents:@{
+        @"hotcodepush.json": [NSJSONSerialization dataWithJSONObject:@{ @"deletedFiles": deletedFiles }
+                                                             options:kNilOptions
+                                                               error:nil],
+        @"CodePush/codepush-binary-patch.json": [self patchManifest],
+        @"CodePush/main.jsbundle.patch": CPTestFixture(@"update.patch"),
+        @"CodePush/assets/badge.png": CPTestBytes(@"an image only the newer update ships"),
+    }];
+}
+
+/* What an asset diff merged into the installed package has to add up to. */
+- (NSString *)stageAssetDiffTargetContents {
+    return [self stageContents:@{
+        @"CodePush/main.jsbundle": CPTestFixture(@"target.bundle"),
+        @"CodePush/assets/logo.png": CPTestBytes(@"an image the update ships with"),
+        @"CodePush/assets/badge.png": CPTestBytes(@"an image only the newer update ships"),
+    }];
+}
+
+#pragma mark - Asserting the outcome
+
+/* Every file under a folder, keyed by its path relative to that folder. */
+- (NSDictionary<NSString *, NSData *> *)filesUnder:(NSString *)folder {
+    NSMutableDictionary *files = [NSMutableDictionary dictionary];
+    NSDirectoryEnumerator *entries = [[NSFileManager defaultManager] enumeratorAtPath:folder];
+    for (NSString *relativePath in entries) {
+        if ([[entries.fileAttributes fileType] isEqualToString:NSFileTypeDirectory]) {
+            continue;
+        }
+        files[relativePath] = [NSData dataWithContentsOfFile:[folder stringByAppendingPathComponent:relativePath]];
+    }
+
+    return files;
+}
+
+/*
+ * The update installed under a hash is the staged contents and nothing else, which is the
+ * whole question for an update that was rebuilt from parts of two archives.
+ */
+- (void)assertInstalledContentsOf:(NSString *)packageHash matchStaging:(NSString *)stagingFolder {
+    NSMutableDictionary *installed = [[self filesUnder:[CodePushPackage getPackageFolderPath:packageHash]] mutableCopy];
+    // Written last, so its presence also says the folder hash check passed.
+    XCTAssertNotNil(installed[UpdateMetadataFileName], @"the update was installed without its metadata");
+    [installed removeObjectForKey:UpdateMetadataFileName];
+
+    NSDictionary *expected = [self filesUnder:stagingFolder];
+    XCTAssertEqualObjects([NSSet setWithArray:installed.allKeys], [NSSet setWithArray:expected.allKeys],
+                          @"the installed files");
+    // Hashed rather than compared as data, so that a mismatch reports two hashes instead of
+    // two bundles.
+    for (NSString *relativePath in expected) {
+        XCTAssertEqualObjects(CPTestSha256Hex(installed[relativePath]), CPTestSha256Hex(expected[relativePath]),
+                              @"the contents of %@", relativePath);
+    }
+}
+
+/* The result of an attempt the update had to be downloaded in full after. */
+- (void)assertFallbackResult:(NSDictionary *)result reason:(NSString *)expectedReason {
+    XCTAssertEqualObjects(result[@"status"], @"fallback");
+    XCTAssertEqualObjects(result[@"fallbackReason"], expectedReason);
+    XCTAssertGreaterThanOrEqual([result[@"applyDurationMs"] doubleValue], 0, @"the attempt is timed");
+}
+
+- (void)assertBinaryPatchFolderRemoved {
+    NSString *workingFolder = [[CodePushPackage getCodePushPath] stringByAppendingPathComponent:@"binary-patch"];
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:workingFolder],
+                   @"the working directory outlived the patch attempt");
+}
+
+#pragma mark - Installing
+
+- (void)testInstallsAnUpdateFromItsFullArchive {
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNil(result, @"a download that never had a patch to try reported one anyway");
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+}
+
+- (void)testInstallsAnUpdateFromItsBinaryPatchArchive {
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stagePatchArchiveContents] named:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result[@"status"], @"applied");
+    XCTAssertNil(result[@"fallbackReason"], @"an applied patch has nothing to report a reason for");
+    XCTAssertGreaterThanOrEqual([result[@"applyDurationMs"] doubleValue], 0, @"the apply is timed");
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+    [self assertBinaryPatchFolderRemoved];
+}
+
+#pragma mark - Falling back to the full archive
+
+- (void)testFallsBackToTheFullArchiveWhenThePatchUrlDoesNotServeAnArchive {
+    // A CDN that answers an error page with a 200 is the realistic way this happens.
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveBytes:CPTestBytes(@"<html><body>404 Not Found</body></html>")
+                                              named:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    [self assertFallbackResult:result reason:CodePushBinaryPatchReasonInvalidManifest];
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+}
+
+- (void)testFallsBackToTheFullArchiveWhenThePatchArchiveCannotBeDownloaded {
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self urlOfMissingFileNamed:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    // A patch archive that never arrived is not one of the outcomes the appliers have a word
+    // for, and no word is invented for it here.
+    [self assertFallbackResult:result reason:nil];
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+}
+
+- (void)testFallsBackToTheFullArchiveWhenApplyingThePatchFails {
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+    NSString *patchStaging = [self stagePatchArchiveContents];
+    CPTestWriteFile([patchStaging stringByAppendingPathComponent:@"CodePush/main.jsbundle.patch"],
+                    CPTestBytes(@"the difference between the two"));
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:patchStaging named:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    [self assertFallbackResult:result reason:CodePushBinaryPatchReasonPatchApplyFailed];
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+}
+
+- (void)testReportsAPackageVerificationFailureWhenTheRestoredUpdateIsNotTheOneTheMetadataPromises {
+    // The patch archive carries an asset the release was not published with, so the bundle it
+    // restores is the promised one while the update it makes is not.
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+    NSString *patchStaging = [self stagePatchArchiveContents];
+    CPTestWriteFile([patchStaging stringByAppendingPathComponent:@"CodePush/assets/extra.png"],
+                    CPTestBytes(@"an image from some other release"));
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:patchStaging named:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    [self assertFallbackResult:result reason:CodePushBinaryPatchReasonPackageVerificationFailed];
+    [self assertInstalledContentsOf:packageHash matchStaging:fullStaging];
+}
+
+#pragma mark - Merging an asset diff
+
+- (void)testInstallsAnAssetDiffUpdateByMergingWithTheInstalledPackage {
+    [self installPackageWithContents:[self stageInstalledArchiveContents]];
+    NSString *updateStaging = [self stageAssetDiffTargetContents];
+    NSString *packageHash = CPTestFolderHash(updateStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:updateStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stageAssetDiffArchiveContentsDeleting:@[@"CodePush/assets/legacy.png"]]
+                                                named:@"diff.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result[@"status"], @"applied");
+    // The asset the diff leaves out is carried over from the installed package, and the one
+    // its manifest names is not.
+    [self assertInstalledContentsOf:packageHash matchStaging:updateStaging];
+}
+
+- (void)testFallsBackToTheFullArchiveWhenTheAssetDiffMergeYieldsTheWrongContents {
+    // A manifest that deletes an asset the update keeps: the merge ends up missing a file the
+    // release was published with, and the update is not the one the hash is for.
+    [self installPackageWithContents:[self stageInstalledArchiveContents]];
+    NSString *updateStaging = [self stageAssetDiffTargetContents];
+    NSString *packageHash = CPTestFolderHash(updateStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:updateStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stageAssetDiffArchiveContentsDeleting:@[@"CodePush/assets/logo.png"]]
+                                                named:@"diff.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    [self assertFallbackResult:result reason:CodePushBinaryPatchReasonPackageVerificationFailed];
+    [self assertInstalledContentsOf:packageHash matchStaging:updateStaging];
+}
+
+- (void)testCopiesTheBundledResourcesWhenAnAssetDiffArrivesWithNoInstalledPackage {
+    // The platforms part here. With nothing installed there is no package to merge into, so
+    // this one copies the bundle and the assets out of the app binary and merges the diff
+    // into those - the update installs. The other platform has no such copy to make: its
+    // merge leaves the update short of the files the diff counts on, the folder hash refuses
+    // it, and the full archive is downloaded instead.
+    NSString *updateStaging = [self stageContents:@{
+        @"CodePush/main.jsbundle": CPTestFixture(@"target.bundle"),
+        @"CodePush/assets/binary.png": CPTestBytes(@"an asset that shipped inside the binary"),
+        @"CodePush/assets/badge.png": CPTestBytes(@"an image only the newer update ships"),
+    }];
+    NSString *packageHash = CPTestFolderHash(updateStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:updateStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stageAssetDiffArchiveContentsDeleting:@[]]
+                                                named:@"diff.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result[@"status"], @"applied");
+    [self assertInstalledContentsOf:packageHash matchStaging:updateStaging];
+}
+
+- (void)testLeavesAFileOutsideThePackageFolderAloneWhenTheAssetDiffManifestNamesOne {
+    // A manifest entry that climbs out of the package folder: the client is not the one that
+    // wrote it, so it must not act on it.
+    [self installPackageWithContents:[self stageInstalledArchiveContents]];
+    NSString *sentinelPath = [[[CodePushPackage getCodePushPath] stringByDeletingLastPathComponent]
+                              stringByAppendingPathComponent:@"sentinel.txt"];
+    CPTestWriteFile(sentinelPath, CPTestBytes(@"a file the update has no business deleting"));
+    // Nothing is deleted from the package, so the merge keeps everything the installed one had.
+    NSString *updateStaging = [self stageContents:@{
+        @"CodePush/main.jsbundle": CPTestFixture(@"target.bundle"),
+        @"CodePush/assets/logo.png": CPTestBytes(@"an image the update ships with"),
+        @"CodePush/assets/legacy.png": CPTestBytes(@"an image the newer update leaves behind"),
+        @"CodePush/assets/badge.png": CPTestBytes(@"an image only the newer update ships"),
+    }];
+    NSString *packageHash = CPTestFolderHash(updateStaging);
+
+    NSError *error = nil;
+    NSDictionary *result = [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": [self serveArchive:updateStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stageAssetDiffArchiveContentsDeleting:@[@"../../sentinel.txt"]]
+                                                named:@"diff.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:sentinelPath],
+                  @"a manifest entry reaching outside the package folder deleted %@", sentinelPath);
+    // Skipping it costs the update nothing, so the diff still installs.
+    XCTAssertEqualObjects(result[@"status"], @"applied");
+    [self assertInstalledContentsOf:packageHash matchStaging:updateStaging];
+
+    // The sentinel sits beside the test packages rather than inside them, so clearing the
+    // updates does not take it away.
+    [[NSFileManager defaultManager] removeItemAtPath:sentinelPath error:nil];
+}
+
+#pragma mark - Reporting the download
+
+- (void)testAnnouncesEachDownloadOfAFallbackAsItsOwnProgressStream {
+    NSString *fullStaging = [self stageFullArchiveContents];
+
+    NSError *error = nil;
+    [self downloadPackage:@{
+        @"packageHash": CPTestFolderHash(fullStaging),
+        @"downloadUrl": [self serveArchive:fullStaging named:@"full.zip"],
+        @"binaryPatchDownloadUrl": [self serveBytes:CPTestBytes(@"<html><body>404 Not Found</body></html>")
+                                              named:@"patch.zip"],
+    } error:&error];
+
+    XCTAssertNil(error);
+    NSMutableArray *completedTotals = [NSMutableArray array];
+    for (NSArray *event in self.progressEvents) {
+        if ([event[0] longLongValue] > 0 && [event[0] isEqualToNumber:event[1]]) {
+            [completedTotals addObject:event[0]];
+        }
+    }
+
+    XCTAssertGreaterThanOrEqual(completedTotals.count, (NSUInteger)2,
+                                @"each of the two downloads announces the byte it completed on");
+    XCTAssertEqual([NSSet setWithArray:completedTotals].count, (NSUInteger)2,
+                   @"the two downloads were announced as one stream of a single total: %@", completedTotals);
+}
+
+- (void)testRemovesTheBinaryPatchWorkingDirectoryWhateverTheOutcomeIs {
+    NSString *fullStaging = [self stageFullArchiveContents];
+    NSString *packageHash = CPTestFolderHash(fullStaging);
+    NSString *fullUrl = [self serveArchive:fullStaging named:@"full.zip"];
+
+    NSError *error = nil;
+    [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": fullUrl,
+        @"binaryPatchDownloadUrl": [self serveArchive:[self stagePatchArchiveContents] named:@"patch.zip"],
+    } error:&error];
+    XCTAssertNil(error);
+    [self assertBinaryPatchFolderRemoved];
+
+    [self downloadPackage:@{
+        @"packageHash": packageHash,
+        @"downloadUrl": fullUrl,
+        @"binaryPatchDownloadUrl": [self serveBytes:CPTestBytes(@"<html><body>404 Not Found</body></html>")
+                                              named:@"not-an-archive.zip"],
+    } error:&error];
+    XCTAssertNil(error);
+    [self assertBinaryPatchFolderRemoved];
+}
+
+#pragma mark - Path guard
+
+/*
+ * The same input table the applier's guard is held to. The two are twins that must not
+ * drift apart, so each is pinned where it lives.
+ */
+- (void)testRefusesAManifestPathThatLeavesTheFolderInThePackageGuard {
+    NSString *folder = [self makeTemporaryFolder];
+
+    XCTAssertNil([CodePushPackage pathInsideFolder:folder relativePath:@"../outside.txt"]);
+    XCTAssertNil([CodePushPackage pathInsideFolder:folder relativePath:@"a/../../outside.txt"]);
+    XCTAssertNil([CodePushPackage pathInsideFolder:folder relativePath:@"/etc/passwd"]);
+    XCTAssertNil([CodePushPackage pathInsideFolder:folder relativePath:@""]);
+    XCTAssertNil([CodePushPackage pathInsideFolder:folder relativePath:nil]);
+
+    // The simulator reaches its temp folder through a symlink, so both sides standardize.
+    XCTAssertEqualObjects([[CodePushPackage pathInsideFolder:folder relativePath:@"CodePush/assets/logo.png"] stringByStandardizingPath],
+                          [[folder stringByAppendingPathComponent:@"CodePush/assets/logo.png"] stringByStandardizingPath]);
+    XCTAssertEqualObjects([[CodePushPackage pathInsideFolder:folder relativePath:@"CodePush/../main.jsbundle"] stringByStandardizingPath],
+                          [[folder stringByAppendingPathComponent:@"main.jsbundle"] stringByStandardizingPath]);
+}
+
+@end

--- a/ios/CodePushTests/CodePushTestHelpers.h
+++ b/ios/CodePushTests/CodePushTestHelpers.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NSString *CPTestSha256Hex(NSData *data);
+NSString *CPTestFolderHash(NSString *folderPath);
+NSString *CPTestMakeTempDirectory(void);
+void CPTestWriteFile(NSString *path, NSData *contents);
+NSData *CPTestFixture(NSString *name);
+BOOL CPTestZipFolderContents(NSString *folderPath, NSString *zipFilePath);
+NSMutableDictionary *CPTestValidPatchManifest(void);
+IMP CPTestReplaceClassMethod(Class cls, SEL selector, id block);
+void CPTestRestoreClassMethod(Class cls, SEL selector, IMP original);

--- a/ios/CodePushTests/CodePushTestHelpers.m
+++ b/ios/CodePushTests/CodePushTestHelpers.m
@@ -1,7 +1,6 @@
 #import "CodePushTestHelpers.h"
 #import <CommonCrypto/CommonDigest.h>
 #import <SSZipArchive/SSZipArchive.h>
-#import <XCTest/XCTest.h>
 #import <objc/runtime.h>
 
 NSString *CPTestSha256Hex(NSData *data) {

--- a/ios/CodePushTests/CodePushTestHelpers.m
+++ b/ios/CodePushTests/CodePushTestHelpers.m
@@ -1,0 +1,106 @@
+#import "CodePushTestHelpers.h"
+#import <CommonCrypto/CommonDigest.h>
+#import <SSZipArchive/SSZipArchive.h>
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+
+NSString *CPTestSha256Hex(NSData *data) {
+    uint8_t digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(data.bytes, (CC_LONG)data.length, digest);
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+        [hex appendFormat:@"%02x", digest[i]];
+    }
+    return hex;
+}
+
+static void CPTestAddEntries(NSString *root, NSString *prefix, NSMutableArray *entries) {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    for (NSString *name in [fileManager contentsOfDirectoryAtPath:root error:nil]) {
+        NSString *relative = prefix.length ? [prefix stringByAppendingPathComponent:name] : name;
+        if ([relative hasPrefix:@"__MACOSX"] || [relative isEqualToString:@".DS_Store"]
+            || [relative hasSuffix:@"/.DS_Store"]) {
+            continue;
+        }
+        NSString *full = [root stringByAppendingPathComponent:name];
+        BOOL isDirectory = NO;
+        [fileManager fileExistsAtPath:full isDirectory:&isDirectory];
+        if (isDirectory) {
+            CPTestAddEntries(full, relative, entries);
+        } else {
+            NSData *contents = [NSData dataWithContentsOfFile:full];
+            [entries addObject:[NSString stringWithFormat:@"%@:%@", relative, CPTestSha256Hex(contents)]];
+        }
+    }
+}
+
+NSString *CPTestFolderHash(NSString *folderPath) {
+    NSMutableArray *entries = [NSMutableArray array];
+    CPTestAddEntries(folderPath, @"", entries);
+    NSArray *sorted = [entries sortedArrayUsingSelector:@selector(compare:)];
+    NSData *json = [NSJSONSerialization dataWithJSONObject:sorted options:kNilOptions error:nil];
+    NSString *text = [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding];
+    text = [text stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
+    return CPTestSha256Hex([text dataUsingEncoding:NSUTF8StringEncoding]);
+}
+
+NSString *CPTestMakeTempDirectory(void) {
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    NSError *error = nil;
+    BOOL created = [[NSFileManager defaultManager] createDirectoryAtPath:path
+                                             withIntermediateDirectories:YES
+                                                              attributes:nil
+                                                                   error:&error];
+    NSCAssert(created, @"%@", error);
+    return path;
+}
+
+void CPTestWriteFile(NSString *path, NSData *contents) {
+    NSError *error = nil;
+    BOOL created = [[NSFileManager defaultManager] createDirectoryAtPath:[path stringByDeletingLastPathComponent]
+                                             withIntermediateDirectories:YES
+                                                              attributes:nil
+                                                                   error:&error];
+    NSCAssert(created, @"%@", error);
+    BOOL written = [contents writeToFile:path options:NSDataWritingAtomic error:&error];
+    NSCAssert(written, @"%@", error);
+}
+
+NSData *CPTestFixture(NSString *name) {
+    NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"CodePushTestHelpersTests")];
+    NSString *path = [bundle pathForResource:[name stringByDeletingPathExtension]
+                                      ofType:[name pathExtension]];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    NSCAssert(data != nil, @"fixture %@ is missing from the test bundle", name);
+    return data;
+}
+
+NSMutableDictionary *CPTestValidPatchManifest(void) {
+    NSData *base = CPTestFixture(@"base.bundle");
+    NSData *target = CPTestFixture(@"target.bundle");
+    return [NSMutableDictionary dictionaryWithDictionary:@{
+        @"formatVersion": @1,
+        @"algorithm": @"hdiffpatch-m-zstd",
+        @"bundlePath": @"main.jsbundle",
+        @"patchFile": @"main.jsbundle.patch",
+        @"baseBundleHash": CPTestSha256Hex(base),
+        @"targetBundleHash": CPTestSha256Hex(target),
+        @"targetBundleSize": @(target.length),
+    }];
+}
+
+BOOL CPTestZipFolderContents(NSString *folderPath, NSString *zipFilePath) {
+    return [SSZipArchive createZipFileAtPath:zipFilePath
+                     withContentsOfDirectory:folderPath
+                         keepParentDirectory:NO];
+}
+
+IMP CPTestReplaceClassMethod(Class cls, SEL selector, id block) {
+    Method method = class_getClassMethod(cls, selector);
+    NSCAssert(method != NULL, @"no class method %@ on %@", NSStringFromSelector(selector), cls);
+    return method_setImplementation(method, imp_implementationWithBlock(block));
+}
+
+void CPTestRestoreClassMethod(Class cls, SEL selector, IMP original) {
+    method_setImplementation(class_getClassMethod(cls, selector), original);
+}

--- a/ios/CodePushTests/CodePushTestHelpersTests.m
+++ b/ios/CodePushTests/CodePushTestHelpersTests.m
@@ -6,7 +6,7 @@
 
 @implementation CodePushTestHelpersTests
 
-/* Reference Facts의 검증 벡터: 독립 구현이 프로덕션과 같은 값을 내는지 고정한다. */
+/* The known vector: this independent implementation has to agree with the production hash. */
 - (void)testFolderHashMatchesTheKnownVector {
     NSString *folder = CPTestMakeTempDirectory();
     CPTestWriteFile([folder stringByAppendingPathComponent:@"CodePush/a.txt"],

--- a/ios/CodePushTests/CodePushTestHelpersTests.m
+++ b/ios/CodePushTests/CodePushTestHelpersTests.m
@@ -1,0 +1,51 @@
+#import <XCTest/XCTest.h>
+#import "CodePushTestHelpers.h"
+
+@interface CodePushTestHelpersTests : XCTestCase
+@end
+
+@implementation CodePushTestHelpersTests
+
+/* Reference Facts의 검증 벡터: 독립 구현이 프로덕션과 같은 값을 내는지 고정한다. */
+- (void)testFolderHashMatchesTheKnownVector {
+    NSString *folder = CPTestMakeTempDirectory();
+    CPTestWriteFile([folder stringByAppendingPathComponent:@"CodePush/a.txt"],
+                    [@"hello" dataUsingEncoding:NSUTF8StringEncoding]);
+    XCTAssertEqualObjects(CPTestFolderHash(folder),
+                          @"3551a1493543d3843bf9b93802cf1449c81b66e40d318809f769e619da252c3f");
+}
+
+- (void)testFolderHashSkipsFilesTheProductionHashSkips {
+    NSString *folder = CPTestMakeTempDirectory();
+    CPTestWriteFile([folder stringByAppendingPathComponent:@"CodePush/a.txt"],
+                    [@"hello" dataUsingEncoding:NSUTF8StringEncoding]);
+    CPTestWriteFile([folder stringByAppendingPathComponent:@".DS_Store"], [NSData data]);
+    CPTestWriteFile([folder stringByAppendingPathComponent:@"CodePush/.DS_Store"], [NSData data]);
+    CPTestWriteFile([folder stringByAppendingPathComponent:@"__MACOSX/junk"], [NSData data]);
+    XCTAssertEqualObjects(CPTestFolderHash(folder),
+                          @"3551a1493543d3843bf9b93802cf1449c81b66e40d318809f769e619da252c3f");
+}
+
+- (void)testLoadsTheCommittedFixtures {
+    XCTAssertEqualObjects(CPTestSha256Hex(CPTestFixture(@"base.bundle")),
+                          CPTestValidPatchManifest()[@"baseBundleHash"]);
+    XCTAssertEqual([CPTestFixture(@"target.bundle") length],
+                   [CPTestValidPatchManifest()[@"targetBundleSize"] longLongValue]);
+    XCTAssertTrue([CPTestFixture(@"update.patch") length] > 0);
+}
+
+- (void)testZipsAFolderIntoItsContents {
+    NSString *staging = CPTestMakeTempDirectory();
+    CPTestWriteFile([staging stringByAppendingPathComponent:@"hotcodepush.json"],
+                    [@"{}" dataUsingEncoding:NSUTF8StringEncoding]);
+    CPTestWriteFile([staging stringByAppendingPathComponent:@"CodePush/main.jsbundle"],
+                    [@"bundle" dataUsingEncoding:NSUTF8StringEncoding]);
+    NSString *zipPath = [CPTestMakeTempDirectory() stringByAppendingPathComponent:@"a.zip"];
+    XCTAssertTrue(CPTestZipFolderContents(staging, zipPath));
+
+    NSData *header = [[NSFileHandle fileHandleForReadingAtPath:zipPath] readDataOfLength:4];
+    const char pk[4] = {'P', 'K', 3, 4};
+    XCTAssertEqualObjects(header, [NSData dataWithBytes:pk length:4]);
+}
+
+@end

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "package.json",
     "THIRD-PARTY-NOTICES",
     "!ios/build",
+    "!ios/CodePushTests",
     "!android/build",
     "!android/app/build",
     "!android/gradle",

--- a/scripts/setupExampleApp/runSetupExampleApp.ts
+++ b/scripts/setupExampleApp/runSetupExampleApp.ts
@@ -282,6 +282,38 @@ async function configureIosVersioning(context: SetupContext): Promise<void> {
       "Podfile platform"
     )
   );
+
+  configureCodePushTestSpec(context);
+}
+
+function configureCodePushTestSpec(context: SetupContext): void {
+  const podfilePath = path.join(context.projectPath, "ios", "Podfile");
+  const testSpecPodLine = [
+    "  # Activates the CodePush pod's unit tests. Autolinking skips a pod that is",
+    "  # already declared, so this replaces the generated declaration and points it",
+    "  # at the repository checkout, where the test sources live.",
+    "  pod 'CodePush', :path => '../../..', :testspecs => ['Tests']",
+    ""
+  ]
+    .map((line) => `${line}\n`)
+    .join("");
+
+  updateTextFile(podfilePath, (content) => {
+    if (content.includes(":testspecs => ['Tests']")) {
+      return content;
+    }
+
+    // replaceAllOrThrow substitutes through a callback, so a `$1` backreference
+    // would land in the Podfile verbatim. Carry the matched line over instead.
+    const targetBlockPattern = /^target '.*' do\n/m;
+    const targetBlockLine = content.match(targetBlockPattern)?.[0] ?? "";
+    return replaceAllOrThrow(
+      content,
+      targetBlockPattern,
+      `${targetBlockLine}${testSpecPodLine}`,
+      "Podfile target block"
+    );
+  });
 }
 
 async function configureAndroidVersioning(context: SetupContext): Promise<void> {


### PR DESCRIPTION
## What

Adds a local-only iOS unit test suite covering the binary patch and asset diff paths, symmetric with the Android JVM suites.

- `CodePush.podspec` declares a `Tests` test spec. Test sources live in `ios/CodePushTests/`; the binary patch fixtures are reused from `cli/fixtures/binary-patch/`, so the same committed patch the CLI tests verify is what the iOS applier restores.
- `Examples/RN0840/ios/Podfile` activates the tests with a manual pod declaration pointing at the repository checkout (autolinking skips a pod that is already declared). As a side effect, the example app now compiles the native library from the checkout for every build; JS and codegen still come from the synced `node_modules` copy.
- The example-app generator (`scripts/setupExampleApp/runSetupExampleApp.ts`) injects the same Podfile wiring into newly generated apps, so replacing RN0840 keeps the tests runnable.
- `CONTRIBUTING.md` documents how to run both native suites. Neither suite runs in CI.
- Production code is untouched: internal methods are reached through category declarations in the test files, and the only swizzles are `+binaryBundleURL` / `+bundleAssetsPath` to control the fake app binary.

## Coverage — 50 tests

| Suite | Tests | Mirrors |
| --- | --- | --- |
| `CodePushTestHelpersTests` | 4 | test-infra self-checks (independent folder-hash implementation pinned to a known vector) |
| `CodePushBinaryPatchTests` | 12 | archive shape table (8 layouts) and the `pathInsideFolder` guard |
| `CodePushBinaryPatchRestoreTests` | 21 | `CodePushBinaryPatchTest` (Android, 22) — 20 direct twins; the 2 exclusions are documented in the file header with replacements |
| `CodePushPackageTests` | 13 | `CodePushUpdateManagerDownloadTest` (10) and most of `CodePushUpdateManagerBinaryPatchTest` (6) |

Unlike the Android JVM suites, which stub the native applier, these tests run the real HPatch + zstd code against the committed fixtures — a successful restore, a corrupt patch header, and codec rejection are all exercised with real bytes.

One platform-specific branch is also pinned by a test: when an asset diff arrives with no installed package, iOS merges against the binary's bundled resources while Android skips the copy and ends up falling back. The shared JS layer only selects a diff URL when an installed package's hash matches a `diffPackages` key, so this branch is reachable only through a narrow race (e.g., a rollback to the binary between update selection and the download's merge), and the folder-hash check guards the outcome either way. The branch predates this PR; the test pins its current behavior.

## How to run

```
cd Examples/RN0840/ios && bundle exec pod install
xcodebuild test -workspace RN0840.xcworkspace -scheme CodePush \
  -destination 'platform=iOS Simulator,name=<an available iPhone>'
```

The suite toggles process-global state (the test configuration flag and two class-method swizzles), so do not enable parallel testing for it.

## Notes for reviewers

- npm package hygiene: `ios/CodePushTests` is excluded from `files`, and the published podspec's test spec is inert unless a consumer explicitly requests `:testspecs` (none do).
- `Examples/RN0840/ios/Podfile.lock` now records the checkout version of CodePush, so root version bumps will touch this lockfile.
