### PR TITLE
test: cover asset diff installs in the E2E suite

### DIFF
--- a/e2e/README.ko.md
+++ b/e2e/README.ko.md
@@ -94,6 +94,16 @@ npm run e2e -- --app Expo55Beta --framework expo --platform ios --maestro-only
 
 patch 설치와 full archive fallback은 같은 내용을 설치하므로 화면만으로는 구분되지 않습니다. 둘을 가르는 것은 앱이 서버에 요청한 archive의 순서이며, 모든 시나리오가 이를 검증합니다: patch 설치는 `[patch]`, fallback은 `[patch, full]`, patch 없이 배포된 릴리스는 `[full]`입니다.
 
+### Phase 7 — Asset Diff 업데이트 (`flows-asset-diff/`)
+
+16. **베이스 업데이트 설치** — 바이너리 패치와 asset을 포함한 베이스 버전을 릴리스하고, Phase 6의 설치 플로우로 기기에 설치합니다. 이 phase의 모든 릴리스는 서로 공유하는 64KB asset 하나와 자기만의 작은 asset 하나를 함께 싣습니다. 따라서 베이스와 업데이트는 언제나 asset 하나를 공유하고, 하나는 서로 다르며, 하나는 업데이트에서 사라집니다.
+17. **업데이트와 asset diff 발행** — 다음 릴리스는 같은 히스토리에 합류합니다. 로컬 설정이 `bundleDownloader`를 제공하므로, 릴리스는 베이스의 full archive를 내려받아 full·patch archive와 함께 asset diff archive를 발행하고, 히스토리에 `diffPackages`로 기록합니다. 러너는 설치 전에 diff archive 자체를 검증합니다: 공유 asset은 빠져 있고, 새 asset은 실려 있으며, 삭제 manifest(`hotcodepush.json`)가 업데이트에서 사라진 asset을 지목하는지 확인합니다.
+   - `1.4.1 → 1.4.2` — 베이스를 실행 중인 클라이언트가 `01-update-from-installed`로 업데이트를 설치하며, diff archive만 내려받습니다. 병합된 내용물이 릴리스된 package hash를 그대로 재현해야 하므로, 이 성공이 곧 삭제와 덮어쓰기가 기기에서 실제로 수행되었다는 증거가 됩니다.
+   - 바이너리에서 `1.4.2` 설치 — diff 릴리스가 그대로 있는 상태에서, 바이너리부터 다시 시작하는 클라이언트는 설치된 업데이트가 없으므로 diff가 발행된 적 없다는 듯 patch archive로 설치합니다.
+   - `1.4.3 → 1.4.4` — 실려 있는 asset이 손상된 diff는 다운로드와 병합까지 진행되지만 package 검증에 실패하고, full archive로 fallback합니다.
+
+diff 설치와 그 fallback 역시 같은 내용을 설치하므로, 모든 시나리오가 내려받은 archive를 다시 검증합니다: diff 설치는 `[diff]`, diff가 서빙할 수 없는 클라이언트는 `[patch]`, fallback은 `[diff, full]`입니다.
+
 ## 아키텍처
 
 ```
@@ -113,12 +123,15 @@ e2e/
 │   ├── download-order.ts   # 서버 요청 기록을 앱이 내려받은 archive 순서로 변환
 │   ├── binary-patch-fixtures.ts  # 베이스 번들 추출과 손상된 patch archive
 │   ├── binary-patch-phase.ts     # 바이너리 패치 시나리오 매트릭스
+│   ├── asset-diff-fixtures.ts    # 발행된 diff archive 검증과 손상 픽스처
+│   ├── asset-diff-phase.ts       # Asset diff 시나리오 매트릭스
 │   └── embedded-bundle-export.ts # export 훅이 바이너리에 담긴 번들을 내보냈는지 검증
 ├── flows/                  # Phase 1: 기본 플로우
 ├── flows-rollback/         # Phase 2: 바이너리로 롤백
 ├── flows-partial-rollback/ # Phase 3: 부분 롤백 (v1.0.2 → v1.0.1)
 ├── flows-optional/         # Phase 4: optional 설치 모드 검증
 ├── flows-binary-patch/     # Phase 6: 바이너리 패치 설치와 fallback
+├── flows-asset-diff/       # Phase 7: 설치된 업데이트 위에 asset diff 설치
 └── scripts/
     └── sleep.js            # Maestro runScript 대기 헬퍼
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -94,6 +94,16 @@ The test runner (`e2e/run.ts`) executes these phases in order:
 
 A patch install and a fallback to the full archive install the same contents, so they look identical on screen. What tells them apart is which archives the app asked the mock server for, which every scenario asserts: `[patch]` for a patch install, `[patch, full]` for a fallback, `[full]` for a release published without a patch.
 
+### Phase 7 — Asset Diff Updates (`flows-asset-diff/`)
+
+16. **Install the base update** — Releases a base version with a binary patch and assets, and installs it with the Phase 6 install flow. Every release in this phase ships a 64KB asset shared by all of them plus one small asset of its own, so a base and its update always share one asset, differ in one, and drop one.
+17. **Publish the update and its asset diff** — The next release joins the same history. The local config provides `bundleDownloader`, so the release downloads the base's full archive and publishes an asset diff archive alongside the full and patch archives, recording it in the history as `diffPackages`. Before anything is installed, the runner asserts the diff at the artifact level: the shared asset stayed out, the new asset travels in it, and the deletion manifest (`hotcodepush.json`) names the asset the update dropped.
+   - `1.4.1 → 1.4.2` — A client running the base installs the update with `01-update-from-installed`, downloading the diff archive alone. The merged contents have to reproduce the released package hash, which is what proves the deletion and the overlay actually happened on the device.
+   - `1.4.2` from the binary — With the diff release still standing, a client starting over from the binary holds no installed update, so it installs through the patch archive as if the diff had never been published.
+   - `1.4.3 → 1.4.4` — A diff whose shipped asset is corrupted downloads and merges, fails the package verification, and falls back to the full archive.
+
+A diff install and its fallback also install the same contents, so every scenario again asserts the downloaded archives: `[diff]` for a diff install, `[patch]` for a client the diff cannot serve, `[diff, full]` for a fallback.
+
 ## Architecture
 
 ```
@@ -113,12 +123,15 @@ e2e/
 │   ├── download-order.ts   # Turns the server's request log into the archives the app downloaded
 │   ├── binary-patch-fixtures.ts  # Base bundle extraction and broken patch archives
 │   ├── binary-patch-phase.ts     # Binary patch scenario matrix
+│   ├── asset-diff-fixtures.ts    # Published diff archive assertions and corruption
+│   ├── asset-diff-phase.ts       # Asset diff scenario matrix
 │   └── embedded-bundle-export.ts # Asserts the export hooks wrote the bundle the binary ships
 ├── flows/                  # Phase 1: basic flows
 ├── flows-rollback/         # Phase 2: rollback to binary
 ├── flows-partial-rollback/ # Phase 3: partial rollback (v1.0.2 → v1.0.1)
 ├── flows-optional/         # Phase 4: optional install mode verification
 ├── flows-binary-patch/     # Phase 6: binary patch install and fallback
+├── flows-asset-diff/       # Phase 7: asset diff install on top of an installed update
 └── scripts/
     └── sleep.js            # Maestro runScript helper for deterministic waits
 ```

--- a/e2e/flows-asset-diff/01-update-from-installed.yaml
+++ b/e2e/flows-asset-diff/01-update-from-installed.yaml
@@ -1,0 +1,43 @@
+appId: ${APP_ID}
+---
+- launchApp
+- runFlow:
+    when:
+      platform: Android
+    file: ../flows/shared/android-dismiss-overlays.yaml
+- runFlow:
+    when:
+      platform: iOS
+    file: ../flows/shared/ios-dismiss-overlays.yaml
+- assertVisible: "React Native.*"
+
+# Start from the installed base update, deliberately not cleared: a diff archive is only
+# offered to a client whose installed update is the base it was built against.
+- tapOn: "Get update metadata"
+- waitForAnimationToEnd:
+    timeout: 10000
+- assertVisible: "METADATA_V${BASE_RELEASE_LABEL}"
+
+# Mandatory update: downloaded, installed and applied without asking
+- tapOn: "Check for updates"
+- waitForAnimationToEnd:
+    timeout: 30000
+# An update that cannot be installed from its diff is downloaded again in full, which
+# takes a second pass over the network before the app restarts.
+- runScript:
+    file: ../scripts/sleep.js
+    env:
+      WAIT_MS: "5000"
+
+- launchApp:
+    stopApp: false
+- tapOn:
+    text: "(?i)^wait$"
+    optional: true
+- assertVisible: "React Native.*"
+- assertVisible: "UPDATED!"
+
+- tapOn: "Get update metadata"
+- waitForAnimationToEnd:
+    timeout: 10000
+- assertVisible: "METADATA_V${RELEASE_LABEL}"

--- a/e2e/helpers/asset-diff-fixtures.ts
+++ b/e2e/helpers/asset-diff-fixtures.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import {
+  type Platform,
+  findFiles,
+  readReleaseHistory,
+  rewriteArchive,
+} from "./binary-patch-fixtures";
+
+/**
+ * Fixtures for the asset diff scenarios: what a published diff archive has to carry, and
+ * the corruption a client has to survive.
+ *
+ * A diff archive is the patch archive with everything the base package already holds
+ * taken out, plus a manifest naming what the base holds that the update dropped. Whether
+ * a client merged its three sources back together correctly is guarded by the package
+ * hash the merged contents have to reproduce, so what these fixtures inspect is the
+ * published artifact - and what they corrupt is aimed at exactly that guard.
+ */
+
+/** Deletion manifest an asset diff archive carries at its root. */
+const ASSET_DIFF_MANIFEST_NAME = "hotcodepush.json";
+
+/**
+ * Collapses an archive entry path and an asset label onto the characters the platforms
+ * agree on. The same source image lands as `assets/e2e-asset-shared.png` on iOS and as
+ * `drawable-mdpi/assets_e2eassetshared.png` on Android, whose resource naming strips
+ * everything outside [a-z0-9_].
+ */
+function normalizeForMatch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function assetToken(label: string): string {
+  return normalizeForMatch(`e2e-asset-${label}`);
+}
+
+/** Raw entry names of an archive, exactly as stored, directories excluded. */
+function listRawArchiveEntries(archivePath: string): string[] {
+  return execFileSync("unzip", ["-Z", "-1", archivePath], { encoding: "utf8" })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.endsWith("/"));
+}
+
+/**
+ * Asserts that a release publishes an asset diff archive against the package another
+ * release published, and returns the diff download URL.
+ *
+ * A diff is only published when it is smaller than the patch archive it derives from,
+ * so a scenario that quietly went out without one would install through the patch and
+ * test nothing of the diff path.
+ */
+export function assertReleaseOffersDiff(
+  scenario: string,
+  platform: Platform,
+  identifier: string,
+  binaryVersion: string,
+  releaseVersion: string,
+  baseReleaseVersion: string,
+): string {
+  const history = readReleaseHistory(platform, identifier, binaryVersion);
+  for (const version of [releaseVersion, baseReleaseVersion]) {
+    if (!history[version]) {
+      throw new Error(`${scenario}: v${version} is missing from the "${identifier}" release history`);
+    }
+  }
+
+  const basePackageHash = history[baseReleaseVersion].packageHash;
+  const diffDownloadUrl = history[releaseVersion].diffPackages?.[basePackageHash];
+  if (!diffDownloadUrl) {
+    throw new Error(
+      `${scenario}: v${releaseVersion} publishes no asset diff against v${baseReleaseVersion} (${basePackageHash}) ` +
+      `(diffPackages: ${JSON.stringify(history[releaseVersion].diffPackages)})`,
+    );
+  }
+
+  console.log(`[assert] ${scenario}: v${releaseVersion} offers an asset diff against v${baseReleaseVersion} (${diffDownloadUrl})`);
+  return diffDownloadUrl;
+}
+
+/**
+ * Asserts that the diff archive is genuinely a diff of the two releases it stands
+ * between: the asset both releases share stayed out, the asset only the update ships
+ * travels in it, and the manifest names the base's dropped asset for deletion.
+ */
+export function assertDiffArchiveShape(
+  scenario: string,
+  archivePath: string,
+  labels: { sharedAssetLabel: string; addedAssetLabel: string; deletedAssetLabel: string },
+): void {
+  const entries = listRawArchiveEntries(archivePath).map(normalizeForMatch);
+
+  if (entries.some((entry) => entry.includes(assetToken(labels.sharedAssetLabel)))) {
+    throw new Error(
+      `${scenario}: the diff archive carries the "${labels.sharedAssetLabel}" asset its base already holds`,
+    );
+  }
+  if (!entries.some((entry) => entry.includes(assetToken(labels.addedAssetLabel)))) {
+    throw new Error(
+      `${scenario}: the diff archive is missing the "${labels.addedAssetLabel}" asset only this update ships`,
+    );
+  }
+
+  const manifest = JSON.parse(
+    execFileSync("unzip", ["-p", archivePath, ASSET_DIFF_MANIFEST_NAME], { encoding: "utf8" }),
+  ) as { deletedFiles: string[] };
+  if (!manifest.deletedFiles.some((file) => normalizeForMatch(file).includes(assetToken(labels.deletedAssetLabel)))) {
+    throw new Error(
+      `${scenario}: the diff manifest does not delete the base's "${labels.deletedAssetLabel}" asset ` +
+      `(deletedFiles: [${manifest.deletedFiles.join(", ")}])`,
+    );
+  }
+
+  console.log(`[assert] ${scenario}: diff archive omits the shared asset and deletes the base's dropped asset`);
+}
+
+/**
+ * Corrupts the marker asset the diff archive ships, leaving everything else as
+ * published.
+ *
+ * Assets are copied, never decoded, so the download, the unzip and the merge all
+ * succeed over the corrupted bytes. The only thing standing between them and the app is
+ * the package hash the merged contents have to reproduce - which is the verification
+ * this corruption isolates, together with the fallback to the full archive behind it.
+ */
+export function corruptDiffArchiveAsset(archivePath: string): void {
+  rewriteArchive(archivePath, (contentsDir) => {
+    const assetPath = findFiles(contentsDir)
+      .find((filePath) => normalizeForMatch(path.basename(filePath)).includes(normalizeForMatch("e2e-asset")));
+    if (!assetPath) {
+      throw new Error(`The diff archive at "${archivePath}" carries no marker asset to corrupt`);
+    }
+
+    const asset = fs.readFileSync(assetPath);
+    for (let offset = 0; offset < asset.length; offset += 1) {
+      asset[offset] = asset[offset] ^ 0xff;
+    }
+    fs.writeFileSync(assetPath, asset);
+  });
+}

--- a/e2e/helpers/asset-diff-phase.ts
+++ b/e2e/helpers/asset-diff-phase.ts
@@ -1,0 +1,165 @@
+/**
+ * Installs updates through their asset diff archives, and what happens to the clients a
+ * diff cannot serve.
+ *
+ * A release published with asset diffs offers up to three archives of the same update. A
+ * client whose installed update is a base the release was diffed against downloads the
+ * diff archive alone; a client the diff cannot serve keeps the patch archive; and a diff
+ * that does not merge back into the released package falls back to the full archive.
+ * All of them end up running identical contents, so - as with the binary patch phase -
+ * what tells the cases apart is which archives the app asked the mock server for.
+ */
+
+import path from "path";
+import { assertArtifactStorageLayout } from "./artifact-storage";
+import {
+  assertDiffArchiveShape,
+  assertReleaseOffersDiff,
+  corruptDiffArchiveAsset,
+} from "./asset-diff-fixtures";
+import {
+  assertReleaseOffersPatch,
+  extractBinaryBundle,
+  findAssetDiffArchive,
+} from "./binary-patch-fixtures";
+import {
+  assertDownloadedArchives,
+  startRecordingDownloads,
+  type DownloadedArchive,
+} from "./download-order";
+import { prepareBundle } from "./prepare-bundle";
+
+/** Binary version every example app release targets, and the name of its history file. */
+const BINARY_VERSION = "1.0.0";
+
+/**
+ * Size of the asset the base and the update share. A diff is only published when it is
+ * smaller than the patch archive, and leaving this asset out is the diff's whole
+ * saving - so it has to dwarf what the diff adds over the patch contents, the deletion
+ * manifest and the zip bookkeeping around it.
+ */
+const SHARED_ASSET_BYTES = 64 * 1024;
+const SHARED_ASSET_LABEL = "shared";
+
+export interface AssetDiffPhaseContext {
+  appPath: string;
+  platform: "ios" | "android";
+  framework?: "expo";
+  /** Identifier the app reads its release history under. */
+  releaseIdentifier: string;
+  /** Android package name or iOS bundle identifier of the installed app. */
+  appId: string;
+  /** Empties the served mock data, so each scenario starts from an empty server. */
+  cleanMockData: () => void;
+  runMaestro: (flowPath: string, flowEnv: Record<string, string>) => Promise<void>;
+  withRetry: (label: string, action: () => Promise<void>) => Promise<void>;
+}
+
+interface AssetDiffScenario {
+  name: string;
+  /** Release the device installs first, and the base the diff is then built against. */
+  baseVersion: string;
+  /** Release published on top of the base, carrying the diff archive under test. */
+  updateVersion: string;
+  /** Breaks the published diff where the scenario needs it broken. */
+  breakDiff?: () => void;
+  /** The archives the app is expected to download installing the update. */
+  expectedDownloads: DownloadedArchive[];
+}
+
+export async function runAssetDiffPhase(context: AssetDiffPhaseContext): Promise<void> {
+  const { appPath, platform, framework, releaseIdentifier } = context;
+
+  const installUpdateFlow = path.resolve(__dirname, "../flows-binary-patch/01-install-update.yaml");
+  const updateFromInstalledFlow = path.resolve(__dirname, "../flows-asset-diff/01-update-from-installed.yaml");
+
+  // A diff carries the bundle patch of its release, and that patch only applies to the
+  // exact bundle that shipped inside the app binary - extracted from the installed app,
+  // exactly as the binary patch phase does.
+  const binaryBundlePath = extractBinaryBundle(platform, context.appId);
+
+  // Every release of this phase ships the shared asset plus one asset of its own, so a
+  // base and its update always share one asset (what makes the diff smaller than the
+  // patch archive), differ in one (what the diff has to carry), and drop one (what the
+  // deletion manifest has to name).
+  const releaseWithAssets = (releaseVersion: string, createHistory: boolean) =>
+    prepareBundle(appPath, platform, releaseIdentifier, framework, {
+      releaseVersion,
+      releaseMarkerVersion: releaseVersion,
+      binaryBundlePath,
+      assetMarkers: [
+        { label: SHARED_ASSET_LABEL, byteSize: SHARED_ASSET_BYTES },
+        { label: releaseVersion },
+      ],
+      createHistory,
+    });
+
+  /**
+   * Retried as a whole: once the update joins the history, a client syncs to it rather
+   * than to the base, so a retry can only rebuild the precondition - the installed base
+   * update - by starting the scenario over from an empty server.
+   */
+  const runDiffScenario = (scenario: AssetDiffScenario) =>
+    context.withRetry(`run-maestro: asset diff (${scenario.name})`, async () => {
+      console.log(`\n=== [prepare-bundle: asset diff ${scenario.baseVersion} (${scenario.name})] ===`);
+      context.cleanMockData();
+      await releaseWithAssets(scenario.baseVersion, true);
+      startRecordingDownloads();
+      await context.runMaestro(installUpdateFlow, { RELEASE_LABEL: scenario.baseVersion });
+      assertDownloadedArchives(`${scenario.name} — base install`, ["patch"]);
+
+      console.log(`\n=== [prepare-bundle: asset diff ${scenario.updateVersion} (${scenario.name})] ===`);
+      await releaseWithAssets(scenario.updateVersion, false);
+      assertArtifactStorageLayout(scenario.name);
+      assertReleaseOffersPatch(scenario.name, platform, releaseIdentifier, BINARY_VERSION, scenario.updateVersion);
+
+      assertReleaseOffersDiff(
+        scenario.name,
+        platform,
+        releaseIdentifier,
+        BINARY_VERSION,
+        scenario.updateVersion,
+        scenario.baseVersion,
+      );
+      assertDiffArchiveShape(scenario.name, findAssetDiffArchive(platform, releaseIdentifier), {
+        sharedAssetLabel: SHARED_ASSET_LABEL,
+        addedAssetLabel: scenario.updateVersion,
+        deletedAssetLabel: scenario.baseVersion,
+      });
+
+      scenario.breakDiff?.();
+
+      startRecordingDownloads();
+      await context.runMaestro(updateFromInstalledFlow, {
+        RELEASE_LABEL: scenario.updateVersion,
+        BASE_RELEASE_LABEL: scenario.baseVersion,
+      });
+      assertDownloadedArchives(scenario.name, scenario.expectedDownloads);
+    });
+
+  await runDiffScenario({
+    name: "asset diff installs on top of the base it was built against",
+    baseVersion: "1.4.1",
+    updateVersion: "1.4.2",
+    expectedDownloads: ["diff"],
+  });
+
+  // The release the last scenario published still stands, diffPackages entry and all,
+  // and its diff was built against an installed update this client does not hold: a
+  // client starting over from the binary has no installed update at all, so the diff
+  // must be passed over for the patch archive exactly as if it had never been published.
+  const binaryClientScenario = "client on the binary passes over the diff and installs the patch";
+  await context.withRetry(`run-maestro: asset diff (${binaryClientScenario})`, async () => {
+    startRecordingDownloads();
+    await context.runMaestro(installUpdateFlow, { RELEASE_LABEL: "1.4.2" });
+    assertDownloadedArchives(binaryClientScenario, ["patch"]);
+  });
+
+  await runDiffScenario({
+    name: "diff that does not merge back into the released package falls back to the full update",
+    baseVersion: "1.4.3",
+    updateVersion: "1.4.4",
+    breakDiff: () => corruptDiffArchiveAsset(findAssetDiffArchive(platform, releaseIdentifier)),
+    expectedDownloads: ["diff", "full"],
+  });
+}

--- a/e2e/helpers/binary-patch-fixtures.ts
+++ b/e2e/helpers/binary-patch-fixtures.ts
@@ -301,7 +301,12 @@ function rewriteArchive(archivePath: string, mutate: (contentsDir: string) => vo
     mutate(resolveContentsDir(stagingDir));
 
     fs.rmSync(archivePath);
-    execFileSync("zip", ["-q", "-r", "-X", archivePath, ...fs.readdirSync(stagingDir)], { cwd: stagingDir });
+    // Archives are stored under their extensionless package hash, and zip appends ".zip"
+    // to a target without an extension - so the archive is written under a name zip will
+    // leave alone, then moved onto the name the download URL points at.
+    const rezipPath = `${archivePath}.rezip.zip`;
+    execFileSync("zip", ["-q", "-r", "-X", rezipPath, ...fs.readdirSync(stagingDir)], { cwd: stagingDir });
+    fs.renameSync(rezipPath, archivePath);
   } finally {
     fs.rmSync(stagingDir, { recursive: true, force: true });
   }

--- a/e2e/helpers/binary-patch-fixtures.ts
+++ b/e2e/helpers/binary-patch-fixtures.ts
@@ -123,7 +123,12 @@ export function readReleaseHistory(
   platform: Platform,
   identifier: string,
   binaryVersion: string,
-): Record<string, { downloadUrl: string; packageHash: string; binaryPatchDownloadUrl?: string }> {
+): Record<string, {
+  downloadUrl: string;
+  packageHash: string;
+  binaryPatchDownloadUrl?: string;
+  diffPackages?: Record<string, string>;
+}> {
   return JSON.parse(fs.readFileSync(getHistoryFilePath(platform, identifier, binaryVersion), "utf8"));
 }
 
@@ -234,10 +239,15 @@ export function findFullArchive(platform: Platform, identifier: string): string 
   return findArchive(platform, identifier, "full-bundle");
 }
 
+/** The one asset diff archive in the served data, stored under its asset-diff artifact type. */
+export function findAssetDiffArchive(platform: Platform, identifier: string): string {
+  return findArchive(platform, identifier, "asset-diff");
+}
+
 function findArchive(
   platform: Platform,
   identifier: string,
-  artifactType: "full-bundle" | "binary-patch",
+  artifactType: "full-bundle" | "binary-patch" | "asset-diff",
 ): string {
   const bundleDir = path.join(MOCK_DATA_DIR, "bundles", platform, identifier);
   const archivePaths = findFiles(bundleDir)
@@ -253,7 +263,7 @@ function findArchive(
   return archivePaths[0];
 }
 
-function findFiles(dir: string): string[] {
+export function findFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) {
     return [];
   }
@@ -292,7 +302,7 @@ export function extractBundleFromArchive(archivePath: string, bundleName: string
  * Rewrites an archive in place, leaving its name - and so the download URL the release
  * history already points at - untouched.
  */
-function rewriteArchive(archivePath: string, mutate: (contentsDir: string) => void): void {
+export function rewriteArchive(archivePath: string, mutate: (contentsDir: string) => void): void {
   fs.mkdirSync(WORK_DIR, { recursive: true });
   const stagingDir = fs.mkdtempSync(path.join(WORK_DIR, "archive-"));
 

--- a/e2e/helpers/binary-patch-phase.ts
+++ b/e2e/helpers/binary-patch-phase.ts
@@ -34,6 +34,7 @@ import {
   type DownloadedArchive,
 } from "./download-order";
 import {
+  type AssetMarker,
   clearReleaseMarker,
   getCodePushReleaseArgs,
   prepareBundle,
@@ -89,7 +90,7 @@ export async function runBinaryPatchPhase(context: BinaryPatchPhaseContext): Pro
 
   const releasePatchUpdate = (
     releaseVersion: string,
-    extraOptions: { assetMarkerVersion?: string; mandatory?: boolean; binaryBundlePath?: string } = {},
+    extraOptions: { assetMarkers?: AssetMarker[]; mandatory?: boolean; binaryBundlePath?: string } = {},
   ) => prepareBundle(appPath, platform, releaseIdentifier, framework, {
     releaseVersion,
     releaseMarkerVersion: releaseVersion,
@@ -127,7 +128,7 @@ export async function runBinaryPatchPhase(context: BinaryPatchPhaseContext): Pro
       flowPath: installUpdateFlow,
       expectedDownloads: ["patch"],
       prepare: async () => {
-        await releasePatchUpdate("1.3.2", { assetMarkerVersion: "1.3.2" });
+        await releasePatchUpdate("1.3.2", { assetMarkers: [{ label: "1.3.2" }] });
         assertPatchArchiveCarriesAssets(
           "patch update carrying assets installs",
           findPatchArchive(platform, releaseIdentifier),

--- a/e2e/helpers/download-order.ts
+++ b/e2e/helpers/download-order.ts
@@ -9,8 +9,13 @@ import { clearRequestLog, getRequestLog } from "../mock-server/server";
  * which archives were requested: a patch install fetches the patch alone, a fallback
  * fetches the patch and then the full archive, and a release without a patch fetches the
  * full archive alone.
+ *
+ * An asset diff archive is a third form of the same contents, offered to a client whose
+ * installed update is the base it was built against, and told apart the same way: a diff
+ * install fetches the diff alone, and a diff that cannot be installed falls back to the
+ * full archive.
  */
-export type DownloadedArchive = "patch" | "full";
+export type DownloadedArchive = "patch" | "diff" | "full";
 
 export function startRecordingDownloads(): void {
   clearRequestLog();
@@ -20,7 +25,11 @@ export function startRecordingDownloads(): void {
 export function getDownloadedArchives(): DownloadedArchive[] {
   return getRequestLog()
     .filter((request) => request.method === "GET" && request.url.startsWith("/bundles/"))
-    .map((request) => (request.url.includes("/binary-patch/") ? "patch" : "full"));
+    .map((request) => {
+      if (request.url.includes("/binary-patch/")) return "patch";
+      if (request.url.includes("/asset-diff/")) return "diff";
+      return "full";
+    });
 }
 
 export function assertDownloadedArchives(scenario: string, expected: DownloadedArchive[]): void {
@@ -35,11 +44,11 @@ export function assertDownloadedArchives(scenario: string, expected: DownloadedA
   console.log(`[assert] ${scenario}: downloaded [${actual.join(", ")}]`);
 }
 
-/** Asserts that no patch archive was offered to the app, let alone downloaded. */
+/** Asserts that no patch or diff archive was offered to the app, let alone downloaded. */
 export function assertNoPatchDownloads(scenario: string): void {
   const archives = getDownloadedArchives();
 
-  if (archives.includes("patch")) {
+  if (archives.some((archive) => archive !== "full")) {
     throw new Error(`${scenario}: expected full archives only, but the app downloaded [${archives.join(", ")}]`);
   }
   if (archives.length === 0) {

--- a/e2e/helpers/prepare-bundle.ts
+++ b/e2e/helpers/prepare-bundle.ts
@@ -1,7 +1,16 @@
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { spawn } from "child_process";
 import { ARTIFACT_LOG_PATH, MOCK_DATA_DIR, getMockServerHost } from "../config";
+
+/** An image asset the released bundle carries. Same label, byte-identical file. */
+export interface AssetMarker {
+  /** Names the asset file, so releases naming the same label share the asset. */
+  label: string;
+  /** Pads the image to this size, for an asset whose size has to decide something. */
+  byteSize?: number;
+}
 
 interface PrepareBundleOptions {
   releaseVersion?: string;
@@ -10,8 +19,10 @@ interface PrepareBundleOptions {
   crashOnStartVersion?: string;
   /** Releases a binary patch against this JS bundle alongside the full bundle. */
   binaryBundlePath?: string;
-  /** Adds an image asset to the released bundle, so the update carries more than JS. */
-  assetMarkerVersion?: string;
+  /** Adds image assets to the released bundle, so the update carries more than JS. */
+  assetMarkers?: AssetMarker[];
+  /** Skipped when the release should join the history that is already being served. */
+  createHistory?: boolean;
 }
 
 export function setReleasingBundle(appPath: string, value: boolean): void {
@@ -77,34 +88,63 @@ export function clearCrashOnStartMarker(appPath: string): void {
   fs.writeFileSync(appTsxPath, content, "utf8");
 }
 
-const ASSET_MARKER_PATTERN = /^global\.__E2E_ASSET__ = require\("\.\/e2e-asset-.*\.png"\);$/m;
+const ASSET_MARKER_PATTERN = /^global\.__E2E_ASSETS__ = \[.*\];$/m;
 const ASSET_MARKER_FILE_PREFIX = "e2e-asset-";
 // Smallest valid PNG, so Metro reads its dimensions and packs it like any other image.
 const ASSET_MARKER_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
 /**
- * Adds an image asset to the released bundle.
+ * Adds image assets to the released bundle.
  *
  * An update is not only its JS bundle, and a binary patch only replaces the bundle: the
  * assets have to travel in the patch archive untouched for the restored contents to be
- * the update. Requiring the image is enough to put it in the update - Metro copies every
- * asset the module graph reaches, whether or not the app draws it.
+ * the update. Requiring the images is enough to put them in the update - Metro copies
+ * every asset the module graph reaches, whether or not the app draws it.
  */
-export function setAssetMarker(appPath: string, version: string): void {
-  const assetFileName = `${ASSET_MARKER_FILE_PREFIX}${version}.png`;
-  fs.writeFileSync(path.join(appPath, assetFileName), Buffer.from(ASSET_MARKER_PNG_BASE64, "base64"));
+export function setAssetMarker(appPath: string, markers: AssetMarker[]): void {
+  const requires = markers.map((marker) => {
+    const assetFileName = `${ASSET_MARKER_FILE_PREFIX}${marker.label}.png`;
+    fs.writeFileSync(path.join(appPath, assetFileName), assetMarkerPng(marker.label, marker.byteSize));
+    return `require("./${assetFileName}")`;
+  });
 
   const appTsxPath = path.join(appPath, "App.tsx");
   let content = fs.readFileSync(appTsxPath, "utf8");
-  // Assigned to a global so that no minifier can decide the asset is unused.
-  const marker = `global.__E2E_ASSET__ = require("./${assetFileName}");`;
+  // Assigned to a global so that no minifier can decide the assets are unused.
+  const marker = `global.__E2E_ASSETS__ = [${requires.join(", ")}];`;
   if (ASSET_MARKER_PATTERN.test(content)) {
     content = content.replace(ASSET_MARKER_PATTERN, marker);
   } else {
     content = `${marker}\n${content}`;
   }
   fs.writeFileSync(appTsxPath, content, "utf8");
+}
+
+/**
+ * The marker image, padded to `byteSize` for an asset whose size matters.
+ *
+ * The padding sits after the IEND chunk, where image decoders stop reading, so Metro
+ * still reads the 1x1 dimensions from the header. It is derived from the label alone,
+ * because both of its uses need it reproducible: two releases only share the asset if
+ * each writes the same bytes, and hash chains do not compress, so the padded size
+ * survives into the zip archives whose sizes are compared when a diff is published.
+ */
+function assetMarkerPng(label: string, byteSize?: number): Buffer {
+  const png = Buffer.from(ASSET_MARKER_PNG_BASE64, "base64");
+  if (!byteSize || byteSize <= png.length) {
+    return png;
+  }
+
+  const blocks: Buffer[] = [png];
+  let length = png.length;
+  let block = crypto.createHash("sha256").update(`${ASSET_MARKER_FILE_PREFIX}${label}`).digest();
+  while (length < byteSize) {
+    blocks.push(block);
+    length += block.length;
+    block = crypto.createHash("sha256").update(block).digest();
+  }
+  return Buffer.concat(blocks).subarray(0, byteSize);
 }
 
 export function clearAssetMarker(appPath: string): void {
@@ -131,7 +171,7 @@ export async function prepareBundle(
   const mandatory = options.mandatory ?? true;
   const releaseMarkerVersion = options.releaseMarkerVersion;
   const crashOnStartVersion = options.crashOnStartVersion;
-  const assetMarkerVersion = options.assetMarkerVersion;
+  const assetMarkers = options.assetMarkers;
 
   setReleasingBundle(appPath, true);
 
@@ -142,17 +182,19 @@ export async function prepareBundle(
     if (crashOnStartVersion) {
       setCrashOnStartMarker(appPath, crashOnStartVersion);
     }
-    if (assetMarkerVersion) {
-      setAssetMarker(appPath, assetMarkerVersion);
+    if (assetMarkers?.length) {
+      setAssetMarker(appPath, assetMarkers);
     }
 
-    await runCodePushCommand(appPath, platform, [
-      "create-history",
-      "-c", "code-push.config.local.ts",
-      "-b", "1.0.0",
-      "-p", platform,
-      "-i", appName,
-    ]);
+    if (options.createHistory ?? true) {
+      await runCodePushCommand(appPath, platform, [
+        "create-history",
+        "-c", "code-push.config.local.ts",
+        "-b", "1.0.0",
+        "-p", platform,
+        "-i", appName,
+      ]);
+    }
     await runCodePushRelease(
       appPath,
       platform,
@@ -169,7 +211,7 @@ export async function prepareBundle(
     if (crashOnStartVersion) {
       clearCrashOnStartMarker(appPath);
     }
-    if (assetMarkerVersion) {
+    if (assetMarkers?.length) {
       clearAssetMarker(appPath);
     }
     setReleasingBundle(appPath, false);

--- a/e2e/run.ts
+++ b/e2e/run.ts
@@ -11,6 +11,7 @@ import { assertArtifactStorageLayout, clearArtifactLog } from "./helpers/artifac
 import { assertNoPatchDownloads, startRecordingDownloads } from "./helpers/download-order";
 import { assertReleaseOffersNoPatch } from "./helpers/binary-patch-fixtures";
 import { runBinaryPatchPhase } from "./helpers/binary-patch-phase";
+import { runAssetDiffPhase } from "./helpers/asset-diff-phase";
 import { assertExportedBundleMatchesBinary } from "./helpers/embedded-bundle-export";
 
 interface CliOptions {
@@ -351,6 +352,19 @@ async function main() {
       releaseIdentifier,
       appId,
       excludeTimingSensitive: options.excludeTimingSensitive ?? false,
+      cleanMockData,
+      runMaestro: (flowPath, flowEnv) => runMaestro(flowPath, options.platform, appId, flowEnv),
+      withRetry: (label, action) => withRetry(label, options.retryCount, retryDelayMs, action),
+    });
+
+    // 14. Run Maestro — Phase 7: asset diff updates
+    console.log("\n=== [run-maestro: phase 7 (asset diff updates)] ===");
+    await runAssetDiffPhase({
+      appPath,
+      platform: options.platform,
+      framework: options.framework,
+      releaseIdentifier,
+      appId,
       cleanMockData,
       runMaestro: (flowPath, flowEnv) => runMaestro(flowPath, options.platform, appId, flowEnv),
       withRetry: (label, action) => withRetry(label, options.retryCount, retryDelayMs, action),

--- a/e2e/templates/code-push.config.local.ts
+++ b/e2e/templates/code-push.config.local.ts
@@ -1,11 +1,13 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- This template has environment-specific dependencies.
 // @ts-nocheck
 import {
+  type BundleDownloadInfo,
   type BundleUploadArtifact,
   CliConfigInterface,
   ReleaseHistoryInterface,
 } from "@bravemobile/react-native-code-push";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 
 const MOCK_DATA_DIR = process.env.E2E_MOCK_DATA_DIR;
@@ -98,6 +100,26 @@ const Config: CliConfigInterface = {
       return {} as ReleaseHistoryInterface;
     }
     return JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+  },
+
+  // Hands the release command a previously released archive, which is what it computes
+  // asset diffs against. The mock server serves MOCK_DATA_DIR directly, so the URL path
+  // recorded in the history is the stored file's path.
+  bundleDownloader: async (
+    archive: BundleDownloadInfo,
+  ): Promise<{ downloadedFilePath: string }> => {
+    const urlPath = decodeURIComponent(new URL(archive.downloadUrl).pathname).replace(/^\//, "");
+    const sourcePath = path.join(MOCK_DATA_DIR, urlPath);
+    if (!fs.existsSync(sourcePath)) {
+      throw new Error(`Released archive not found in the mock data: ${sourcePath}`);
+    }
+
+    // Copied into a directory of its own: bases of one release share a file name shape,
+    // and the command may download several of them side by side.
+    const downloadDir = fs.mkdtempSync(path.join(os.tmpdir(), "codepush-e2e-base-"));
+    const downloadedFilePath = path.join(downloadDir, path.basename(sourcePath));
+    fs.copyFileSync(sourcePath, downloadedFilePath);
+    return { downloadedFilePath };
   },
 
   setReleaseHistory: async (


### PR DESCRIPTION
## Background

The asset diff feature (#167–#169) ships per-base diff archives, but the E2E suite never exercised them: no release in the suite published a diff, and the download-order oracle only knew full and patch archives.

## Changes

- **Phase 7 (`asset-diff-phase.ts`)** — three scenarios, each asserting which archives the app asked the mock server for on top of the on-screen outcome:
  - A client running the base installs the next release from the diff archive alone (`[diff]`). The merged contents have to reproduce the released package hash, so this also proves the deletion manifest and the asset overlay ran on the device.
  - A client starting over from the binary installs the same release through the patch archive (`[patch]`), passing over the `diffPackages` entry built for a base it does not hold.
  - A diff whose shipped asset is corrupted downloads and merges, fails the package verification, and falls back to the full archive (`[diff, full]`).
- The E2E config template gains the `bundleDownloader` the release command needs to build diffs; the mock server URL path doubles as the local storage path.
- Asset markers now support multiple assets per release with deterministic size padding, so a base and its update share one 64KB incompressible asset — what makes the diff smaller than the patch archive — while differing in one asset and dropping one.
- `download-order.ts` classifies `/asset-diff/` downloads as a third archive kind, and the full-only assertion now rejects diffs too.
- Archive-level fixtures (`asset-diff-fixtures.ts`) assert the published diff omits the shared asset, carries the new one, and names the dropped one in `hotcodepush.json` — and corrupt the diff's asset for the fallback scenario.
- Fixes a latent `rewriteArchive` bug exposed by #173's extensionless storage keys: `zip` appends `.zip` to a target without an extension, so every corruption fixture re-zipped the archive under a name the download URL no longer pointed at. The archive is now zipped under a suffixed name and moved back onto its stored name.

## Verification

- Full suite green on iOS (iPhone 17 Pro simulator) and Android (emulator): `npm run e2e -- --app RN0840 --platform ios` and `--platform android`. Phases 1–6 behave as before; phase 7 asserts `[diff]`, `[patch]`, and `[diff, full]` in turn.
- `npm run type:e2e` green.