### PR TITLE
docs: cover the options and functions the JS API reference was missing

### DIFF
--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -28,8 +28,8 @@ When you require `react-native-code-push`, the module object provides the follow
 
 * [sync](#codepushsync): Allows checking for an update, downloading it and installing it, all with a single call. Unless you need custom UI and/or behavior, we recommend most developers to use this method when integrating CodePush into their apps
 
-* [clearUpdates](#clearupdates): Clear all downloaded CodePush updates. This is useful when switching to a different deployment which may have an older release than the current package. 
-   
+* [clearUpdates](#codepushclearupdates): Clear all downloaded CodePush updates. This is useful when switching to a different deployment which may have an older release than the current package.
+
     _Note: we don’t recommend to use this method in scenarios other than that (CodePush will call this method automatically when needed in other cases) as it could lead to unpredictable behavior._
 
 #### codePush
@@ -528,6 +528,18 @@ This method returns a `Promise` which is resolved to a `SyncStatus` code that in
 * __codePush.SyncStatus.SYNC_IN_PROGRESS__ *(4)* - There is an ongoing `sync` operation running which prevents the current call from being executed.
 
 The `sync` method can be called anywhere you'd like to check for an update. That could be in the `componentWillMount` lifecycle event of your root component, the onPress handler of a `<TouchableHighlight>` component, in the callback of a periodic timer, or whatever else makes sense for your needs. Just like the `checkForUpdate` method, it will perform the network request to check for an update in the background, so it won't impact your UI thread and/or JavaScript thread's responsiveness.
+
+#### codePush.clearUpdates
+
+```javascript
+codePush.clearUpdates(): void;
+```
+
+Clears all of the CodePush updates that have been downloaded to the device, which gives precedence back to the JS bundle inside the app binary the next time the app is restarted.
+
+This is useful when switching to a different deployment which may have an older release than the current package.
+
+*Note: we don’t recommend using this method in scenarios other than that one, as it could lead to unpredictable behavior. CodePush calls it itself when it is needed - for example when the release history says the app has to roll back to the binary.*
 
 #### Package objects
 

--- a/docs/api-js.md
+++ b/docs/api-js.md
@@ -122,13 +122,31 @@ The `codePush` decorator accepts an "options" object that allows you to customiz
 
 * __deploymentKey__ *(String)* - Specifies the deployment key you want to query for an update against. By default, this value is derived from the `Info.plist` file (iOS) and `MainActivity.java` file (Android), but this option allows you to override it from the script-side if you need to dynamically use a different deployment.
 
+* __ignoreFailedUpdates__ *(never)* - Not accepted by the decorator. `CodePushOptions` types this option as `never`, so it can only be passed to an individual [`sync`](#codepushsync) call, and it is described in the [`SyncOptions`](#syncoptions) reference.
+
 * __installMode__ *(codePush.InstallMode)* - Specifies when you would like to install optional updates (i.e. those that aren't marked as mandatory). Defaults to `codePush.InstallMode.ON_NEXT_RESTART`. Refer to the [`InstallMode`](#installmode) enum reference for a description of the available options and what they do.
 
 * __mandatoryInstallMode__ *(codePush.InstallMode)* - Specifies when you would like to install updates which are marked as mandatory. Defaults to `codePush.InstallMode.IMMEDIATE`. Refer to the [`InstallMode`](#installmode) enum reference for a description of the available options and what they do.
 
 * __minimumBackgroundDuration__ *(Number)* - Specifies the minimum number of seconds that the app needs to have been in the background before restarting the app. This property only applies to updates which are installed using `InstallMode.ON_NEXT_RESUME` or `InstallMode.ON_NEXT_SUSPEND`, and can be useful for getting your update in front of end users sooner, without being too obtrusive. Defaults to `0`, which has the effect of applying the update immediately after a resume or unless the app suspension is long enough to not matter, regardless how long it was in the background.
 
-* __onUpdateArchiveResult__ *((label: String, result: UpdateArchiveResult) => void)* - Called once for an update that was published with a binary patch, after that update has been downloaded and before it is installed. It receives the label of the release the update carries and an `UpdateArchiveResult` reporting whether one of the update's patch archives produced it or the full archive had to be downloaded instead, which archive the last attempt was against, and why each archive that was given up on was. A fallback is not an error: the update arrives either way. The callback is purely for observation - the library neither stores the result nor sends it anywhere, registering no callback changes nothing about the update, and one that throws is logged rather than failing the download it is reporting on. Refer to the `UpdateArchiveResult` type in [typings/react-native-code-push.d.ts](../typings/react-native-code-push.d.ts) for the shape of the result.
+* __onDownloadStart__ *((label: String) => void)* - Called when the download of an available update begins, with the label of the release being downloaded.
+
+* __onDownloadSuccess__ *((label: String) => void)* - Called when the download of an update has completed successfully, with the label of the release that was downloaded. The install happens afterwards, so this says nothing about whether the update could be installed.
+
+* __onRolloutSkipped__ *((label: String) => void)* - Called when the device falls outside the latest release's active rollout, with the label of that release. The update check then leaves that release out of the candidates: it either resolves against the release below it, or - when the release left as the latest one is the binary version - clears the downloaded updates and restarts the app onto the binary. *NOTE: the typings declare a second `error` parameter, but the runtime only ever passes the label.*
+
+* __onSyncError__ *((label: String, error: Error) => void)* - Called when the sync process fails with an unknown error, i.e. it ends in the [`SyncStatus.UNKNOWN_ERROR`](#syncstatus) state. It receives the label of the release being synced - `"unknown"` when the sync failed before a release was resolved - and the error that ended it.
+
+* __onUpdateArchiveResult__ *((label: String, result: UpdateArchiveResult) => void)* - Called once for an update that was published with a binary patch, after that update has been downloaded and before it is installed, with the label of the release it carries. The `UpdateArchiveResult` reports which archive the update came from and why each archive that was given up on was; refer to the `UpdateArchiveResult` type in [typings/react-native-code-push.d.ts](../typings/react-native-code-push.d.ts) for its shape. A fallback is not an error: the update arrives either way. The callback is purely for observation - the library neither stores the result nor sends it anywhere, registering no callback changes nothing about the update, and one that throws is logged rather than failing the download it is reporting on.
+
+* __onUpdateRollback__ *((label: String) => void)* - Called when an installed update failed to run and was rolled back to the previous version, with the label of the release that was rolled back. Like `onUpdateSuccess`, it is reported when the app next confirms its state through `notifyAppReady`.
+
+* __onUpdateSuccess__ *((label: String) => void)* - Called when an installed update has run successfully, with the label of the release that ran. The report is sent when [`notifyAppReady`](#codepushnotifyappready) marks the update successful, which [`sync`](#codepushsync) does for you.
+
+* __releaseHistoryFetcher__ *((updateRequest: UpdateCheckRequest) => Promise&lt;ReleaseHistoryInterface&gt;)* - **Required.** Specifies the function that supplies the release history an update is picked from. It receives an `UpdateCheckRequest` describing the running app - its binary version, package hash, currently running label and client id - and must resolve to a `ReleaseHistoryInterface` for that binary version. There is no default: configuring the plugin without one throws. Refer to ["CodePush-ify" Your App](../README.md#4-codepush-ify-your-app) for an example implementation, and to the `ReleaseHistoryInterface` type in [typings/react-native-code-push.d.ts](../typings/react-native-code-push.d.ts) for what it has to return.
+
+* __updateChecker__ *((updateRequest: UpdateCheckRequest) => Promise&lt;{ update_info: UpdateCheckResponse }&gt;)* - *Deprecated.* Specifies a function that performs the update check itself, so it can be self-hosted. It will be removed in the next major version - `releaseHistoryFetcher` replaces it. Setting it takes that function out of the path entirely: it is never called, though it is still required, so pass a no-op such as `async () => ({})`. No rollout evaluation is applied to what the checker returns.
 
 * __updateDialog__ *(UpdateDialogOptions)* - An "options" object used to determine whether a confirmation dialog should be displayed to the end user when an update is available, and if so, what strings to use. Defaults to `null`, which has the effect of disabling the dialog completely. Setting this to `true` will enable the dialog with the default strings, and passing an object to this parameter allows enabling the dialog as well as overriding one or more of the default strings. Before enabling this option within an App Store-distributed app, please refer to [this note](https://github.com/microsoft/react-native-code-push#app-store).
 
@@ -412,9 +430,11 @@ codePush.sync({ updateDialog: true, installMode: codePush.InstallMode.IMMEDIATE 
 
 ##### SyncOptions
 
-While the `sync` method tries to make it easy to perform silent and active updates with little configuration, it accepts an "options" object that allows you to customize numerous aspects of the default behavior mentioned above. The options available are identical to the [CodePushOptions](#codepushoptions), with the exception of the `checkFrequency` option:
+While the `sync` method tries to make it easy to perform silent and active updates with little configuration, it accepts an "options" object that allows you to customize numerous aspects of the default behavior mentioned above. The options available are identical to the [CodePushOptions](#codepushoptions), with the exception of the `checkFrequency` option, which only the decorator accepts, and the `ignoreFailedUpdates` option, which only `sync` accepts:
 
 * __deploymentKey__ *(String)* - Refer to [`CodePushOptions`](#codepushoptions).
+
+* __ignoreFailedUpdates__ *(Boolean)* - Specifies whether to skip an update whose installation has already failed on this device and been rolled back. Defaults to `true`, so such a release is never offered again. Setting it to `false` makes `sync` retry that release on every call, which - depending on how you release - can leave the app in an endless retry loop if the release cannot be installed at all. This option is only accepted here: [`CodePushOptions`](#codepushoptions) types it as `never`, so the decorator cannot set it.
 
 * __installMode__ *(codePush.InstallMode)* - Refer to [`CodePushOptions`](#codepushoptions).
 
@@ -423,6 +443,8 @@ While the `sync` method tries to make it easy to perform silent and active updat
 * __minimumBackgroundDuration__ *(Number)* - Refer to [`CodePushOptions`](#codepushoptions).
 
 * __onUpdateArchiveResult__ *((label: String, result: UpdateArchiveResult) => void)* - Refer to [`CodePushOptions`](#codepushoptions).
+
+* __rollbackRetryOptions__ *(RollbackRetryOptions)* - Refer to [`CodePushOptions`](#codepushoptions).
 
 * __updateDialog__ *(UpdateDialogOptions)* - Refer to [`CodePushOptions`](#codepushoptions).
 


### PR DESCRIPTION

## Background

`docs/api-js.md` is the JS API reference. It came from upstream Microsoft CodePush and never caught up with what this fork added, so it documented 8 of `CodePushOptions`' 17 options.

The most consequential omission: **`releaseHistoryFetcher` is required** — an app cannot be configured without it — and the reference did not mention it exists. Six callbacks this fork added were described in the README's "4-1. Telemetry Callbacks" section but nowhere in the reference. And `clearUpdates` was the only one of the namespace's eight functions with no section at all, which is why the entry at the top of the file linked to an anchor that resolved to nothing.

None of this is new drift. It is what the reference has looked like since the fork started adding options.

## Changes

**`CodePushOptions` — nine entries added.** `releaseHistoryFetcher` (required, with what it receives and must return), `updateChecker` (deprecated, what replaces it, and that setting it takes `releaseHistoryFetcher` out of the path entirely), `ignoreFailedUpdates` (typed `never` here, so accepted only by `sync()` — the restriction is documented rather than glossed), and the six callbacks `onUpdateSuccess`, `onUpdateRollback`, `onDownloadStart`, `onDownloadSuccess`, `onSyncError`, `onRolloutSkipped`.

**`SyncOptions` — two entries added.** `ignoreFailedUpdates`, documented in full here since this is where it is actually usable, and `rollbackRetryOptions`. The section's intro claimed the two option sets differ only in `checkFrequency`; that stops being true once `ignoreFailedUpdates` is listed, so it now names both exceptions.

**`codePush.clearUpdates` — new section**, and the link at the top of the file now points at an anchor that exists. The link's target changed from `#clearupdates` to `#codepushclearupdates`, matching the eight sibling entries; a bare `#### clearUpdates` heading would have resolved the old anchor but broken the naming every other function section follows.

**`onUpdateArchiveResult`** was restructured while adjacent entries were being written — it had grown into one run-on entry carrying call timing, the result's composition, fallback semantics, the observation-only guarantee and the type link.

Existing entries were not reordered. `rollbackRetryOptions` still sits out of alphabetical order after `updateDialog`'s sub-list, where it already was.

## Verification

Nothing checks this file automatically, which is why it drifted. The check is a survey that pulls the option names out of the typings and subtracts the ones the reference lists:

```bash
T=typings/react-native-code-push.d.ts
{ awk '/^export interface CodePushOptions/,/^}/' $T; awk '/^export interface SyncOptions/,/^}/' $T; } \
  | grep -oE '^    [a-zA-Z]+\??:' | tr -d ' ?:' | sort -u > /tmp/all.txt
awk '/^##### CodePushOptions/{c=1} c&&/^##### /&&!/CodePushOptions/{exit} c' docs/api-js.md \
  | grep -oE '^\* __[a-zA-Z]+__' | sed 's/\* __//; s/__//' | sort > /tmp/doc.txt
comm -23 /tmp/all.txt /tmp/doc.txt
```

Empty for both sections after these commits. Every in-page anchor was also checked against the real headings: 19 unique targets, 26 headings, none unresolved.

`npm run jest` 259/259 and `type:cli` / `type:scripts` / `type:e2e` all green — formality for a markdown change, but run. Only `docs/api-js.md` changed.

Note that `npm run typecheck` does not pass on this stack: `type:src` fails at `src/specs/NativeCodePush.ts:4` with TS2305 on `EventEmitter`, which predates all of this work.

## Follow-ups

- **`onRolloutSkipped`'s type is wrong.** `typings/react-native-code-push.d.ts:234` declares `(label: string, error: Error) => void`, but `src/CodePush.js:86` calls `onRolloutSkipped?.(latestVersion)` — one argument, and there is no error on that path at all; the release was passed over by a rollout bucket check, not by a failure. A TypeScript app reading `error.message` compiles and then crashes. The reference documents the runtime signature and flags the mismatch inline; fixing the type is a production change and did not belong here.
- **The survey above should be a script.** Wiring it into `npm run` would catch the next option added without a reference entry, which is the only reason this gap grew as large as it did.
