### PR TITLE
docs: clarify diff updates and telemetry callbacks

### DIFF
--- a/cli/README.ko.md
+++ b/cli/README.ko.md
@@ -156,7 +156,7 @@ patch는 대체하려는 archive보다 작을 때만 배포할 가치가 있습�
 #### base 번들 검증
 
 `--binary-bundle-path`가 가리키는 번들은 릴리스가 스스로 검증할 수 없는 유일한 입력이므로,
-[build 훅](../docs/diff-updates.ko.md#내장-번들-export하기)은 export하는 번들 옆에
+[build 훅](../docs/diff-updates.ko.md#1-내장-번들-export하기)은 export하는 번들 옆에
 `binary-patch-base.json` 기록을 함께 남깁니다. 이 기록이 있으면 base 번들의 실제 SHA-256이
 기록과 다르거나 `--binary-version`이 아닌 다른 바이너리 버전에서 export된 번들일 때, 빌드나
 업로드를 시작하기 전에 릴리스를 실패시킵니다. 기록이 없는 base 번들은 기존과 동일하게

--- a/cli/README.md
+++ b/cli/README.md
@@ -157,7 +157,7 @@ anything is uploaded and leaves the release history untouched.
 #### Verifying the base bundle
 
 The bundle `--binary-bundle-path` points at is the one input a release cannot verify on
-its own, so the [build hooks](../docs/diff-updates.md#exporting-the-embedded-bundle) leave a
+its own, so the [build hooks](../docs/diff-updates.md#1-export-the-embedded-bundle) leave a
 `binary-patch-base.json` record next to every bundle they export. When that record is
 there, the release fails before anything is built or uploaded if the base bundle no longer
 hashes to what the record describes, or if it was exported from a binary version other

--- a/docs/diff-updates.ko.md
+++ b/docs/diff-updates.ko.md
@@ -1,25 +1,57 @@
 # Diff 업데이트
 
-[English](diff-updates.md)
+[English](./diff-updates.md)
 
-릴리스는 업데이트 전체를 내려주는 대신, 업데이트와 클라이언트가 이미 가진 번들 사이의 차이만 제공할 수 있습니다. 차이는 두 종류이고, asset diff는 binary patch를 담은 릴리스에서만 배포됩니다.
+release 명령은 기본적으로 업데이트 전체를 담은 **full 아카이브**를 배포합니다. Diff 업데이트를 업데이트에 필요한 차이만 내려받도록 할 수 있습니다.
 
-- **binary patch**는 스토어에 올린 앱 바이너리가 내장한 JS 번들을 기준으로 계산합니다. 같은 바이너리 버전을 설치한 기기는 내장 번들이 모두 동일하므로, 그 버전을 쓰는 클라이언트는 전부 binary patch를 적용할 수 있습니다.
-- **asset diff**는 최근에 배포한 OTA 업데이트를 기준으로 계산합니다. 기준이 된 업데이트를 실행 중인 클라이언트만 적용할 수 있습니다. binary patch가 모든 asset을 담는 것과 달리, 기준 업데이트에 없는 asset만 담습니다.
+이 기능은 선택 사항입니다. 아무것도 설정하지 않으면 `release`는 full 아카이브만 배포합니다. 또한 diff 업데이트를 사용할 수 없거나 적용에 실패해도, 네트워크 연결 오류가 아닌 한 앱은 full 아카이브로 fallback하여 업데이트를 설치합니다.
 
-둘 다 쓸 수 없는 클라이언트는 full 아카이브를 내려받으므로 어느 경우에도 릴리스는 설치됩니다. 이 기능은 전부 선택 사항입니다. 아무것도 설정하지 않으면 `release`는 full 아카이브만 배포합니다.
+## 어떤 아카이브가 배포되나요?
 
-patch를 배포하려면 두 가지가 필요합니다. binary patch에는 기준으로 삼는 바이너리 버전마다 내장 번들이 있어야 하고, 이 준비는 [내장 번들 export하기](#내장-번들-export하기)에서 설명합니다. asset diff에는 그에 더해 `code-push.config.ts`의 `bundleDownloader`가 필요하며 [asset diff 아카이브](#asset-diff-아카이브)에서 다룹니다. patch 생성 도구 자체는 첫 patch 릴리스 전에 한 번 빌드해야 합니다. [사전 준비: patch 생성 도구 빌드](../cli/README.ko.md#사전-준비-patch-생성-도구-빌드)를 참고하세요.
+| 아카이브 | 비교 기준 | 포함 내용 | 사용할 수 있는 상황 |
+| --- | --- | --- | --- |
+| full | 없음 | 업데이트 전체 | 언제든 사용 가능 |
+| binary patch | 앱 바이너리에 내장된 JS 번들 | JS 번들 차이와 모든 asset | 비교 기준 바이너리 버전을 실행 중인 경우 |
+| asset diff | 이전 OTA 업데이트 | JS 번들 차이, 새 asset, 삭제할 asset 목록 | 비교 기준 OTA 업데이트를 실행 중인 경우 |
 
-## 내장 번들 export하기
+### binary patch
 
-binary patch는 업데이트와 설치된 앱 안에 이미 들어 있는 JS 번들의 차이입니다. patch를 배포한다는 것은 그 번들, 즉 스토어에 올린 빌드가 내장한 바이트를 그대로 보관해 둔다는 뜻입니다.
+binary patch는 스토어에 배포한 앱 바이너리의 내장 JS 번들을 기준으로 산출됩니다.
 
-라이브러리는 플랫폼마다 훅을 제공합니다. 이 훅은 방금 컴파일된 번들을 빌드에서 복사해 내보내고, 그 번들을 설명하는 `binary-patch-base.json` 기록을 함께 남깁니다.
+같은 배포 대상(binary version)이면 동일한 내장 번들이 들어있어야 합니다. 내장 번들을 보관해두면 같은 바이너리 버전을 대상으로 배포하는 업데이트는 모두 binary patch를 적용할 수 있습니다.
 
-**Android** - 앱 모듈의 `android/app/build.gradle`에 Gradle 스크립트를 적용합니다.
+### asset diff
 
-```groovy
+asset diff는 이전에 배포한 OTA 업데이트를 기준으로 산출됩니다. 따라서 기준이 된 OTA 업데이트를 실행 중인 앱에서만 이 방식의 업데이트를 사용할 수 있습니다.
+
+binary patch가 모든 asset을 담는 것과 달리, asset diff에는 기준 업데이트에 없던 asset만 포함됩니다. 기준 업데이트와 새 릴리스의 asset 차이가 작을수록 이 업데이트의 크기도 작아집니다.
+
+## 시작하기 전에 준비할 것
+
+Diff 업데이트를 배포하려면 다음이 필요합니다.
+
+1. **binary patch용 내장 번들 export**
+   지원할 바이너리 버전마다, 실제 스토어 바이너리에 들어간 JS 번들을 보관해야 합니다.
+
+2. **asset diff용 이전 아카이브 다운로드 설정**
+   asset diff도 배포하려면 `code-push.config.ts`에 `bundleDownloader`를 구현해야 합니다.
+
+또한 패치 생성 전에 생성 도구를 한 번 빌드해야 합니다. 자세한 내용은 [**사전 준비: patch 생성 도구 빌드**](../cli/README.ko.md#사전-준비-patch-생성-도구-빌드)를 참고하세요.
+
+## 1. 내장 번들 export하기
+
+binary patch는 새 업데이트와 앱 안에 이미 들어 있는 JS 번들의 차이를 비교해 만들어집니다. 따라서 스토어에 올린 빌드가 내장한 JS 번들 바이트코드를 그대로 보관해야 합니다.
+
+라이브러리는 플랫폼별 export 훅을 제공합니다. 훅은 번들 빌드가 끝난 뒤 다음을 export합니다.
+
+- Hermes 컴파일된 JS 번들 (바이트코드)
+- 번들의 정보와 검증 값을 담은 `binary-patch-base.json`
+
+### Android
+
+앱 모듈의 `android/app/build.gradle`에 Gradle 스크립트를 적용합니다.
+
+```gradle
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
@@ -30,86 +62,165 @@ react {
 apply from: "../../node_modules/@bravemobile/react-native-code-push/android/codepush-export.gradle"
 ```
 
-이 줄은 파일 안 어디에 두어도 됩니다. `ext.codePushExportDir`를 쓴다면 `apply from:` 줄보다 앞에서 설정해야 합니다. 그러면 JS를 번들링하는 variant마다 번들링을 마친 뒤 `android/app/build/codepush/embedded-bundle/<variant>/`로 export합니다. 다른 위치로 내보내려면 `-PcodePushExportDir=<path>`를 전달하거나 `ext.codePushExportDir`를 설정하세요. 어느 쪽이든 `<variant>` 디렉터리가 뒤에 붙습니다.
+`apply from`은 파일 안 어디에 두어도 좋습니다.
 
-**iOS** - **"Bundle React Native code and images"** build phase의 마지막에서 export 스크립트를 호출합니다. Xcode에서 앱 타깃의 **Build Phases** 탭을 열어 그 phase를 찾고, 스크립트 끝에 아래 마지막 줄을 덧붙입니다.
+앱 빌드 과정에서 JS 번들이 끝나면 다음 경로로 번들을 내보냅니다.
 
-```bash
+```text
+android/app/build/codepush/embedded-bundle/<variant>/
+```
+
+만약 경로를 다른 위치로 설정하려면 다음 중 한 가지 방법을 사용하세요.
+
+- Gradle 실행 시 `-PcodePushExportDir=<path>` 전달
+- `ext.codePushExportDir` 설정
+
+`ext.codePushExportDir`를 설정한다면 `apply from`보다 앞에 두어야 합니다. 어느 방법을 사용해도 마지막에 `<variant>` 디렉터리가 붙습니다.
+
+### iOS
+
+Xcode에서 앱 타깃의 **Build Phases** 탭을 열고 **Bundle React Native code and images** phase를 찾습니다. 기존 스크립트의 마지막에 아래 줄을 추가합니다.
+
+```sh
 /bin/sh -c "\"$WITH_ENVIRONMENT\" \"$REACT_NATIVE_XCODE\""
 
+# 추가하세요
 "$SRCROOT/../node_modules/@bravemobile/react-native-code-push/scripts/export-embedded-bundle.sh"
 ```
 
-export 결과는 `$BUILD_DIR/codepush/embedded-bundle/$CONFIGURATION-$PLATFORM_NAME/`에 생깁니다. 다른 위치로 내보내려면 `CODEPUSH_EXPORT_DIR` 환경 변수를 설정하세요. 어느 쪽이든 `$CONFIGURATION-$PLATFORM_NAME` 디렉터리가 뒤에 붙습니다.
+기본 export 경로는 다음과 같습니다.
 
-> [!NOTE]
-> Expo config plugin(`app.plugin.js`)으로 이 훅을 자동 적용하는 기능은 아직 구현되지 않았습니다.
+```text
+$BUILD_DIR/codepush/embedded-bundle/$CONFIGURATION-$PLATFORM_NAME/
+```
 
-### 바이너리 릴리스별로 export 보관하기
+만약 경로를 다른 위치로 설정하려면 `CODEPUSH_EXPORT_DIR` 환경 변수를 설정하세요. 이 경우에도 마지막에 `$CONFIGURATION-$PLATFORM_NAME` 디렉터리가 붙습니다.
 
-스토어 바이너리를 빌드하는 파이프라인은 빌드마다 나온 export를 바이너리 버전별로 정리해 오래 남는 곳에 보관해야 합니다. 이후 릴리스가 대상 바이너리에 맞는 번들을 가져올 수 있어야 하기 때문입니다.
+> **참고:** Expo config plugin(`app.plugin.js`)으로 이 훅을 자동 적용하는 기능은 아직 제공하지 않습니다.
 
-```bash
-# Android, ./gradlew :app:assembleRelease 실행 후
+## 2. 바이너리 릴리스별 export 보관하기
+
+스토어 바이너리를 빌드하는 CI 파이프라인은 export한 JS 번들을 바이너리 버전별로 구분해 보관해야 합니다.
+
+나중에 OTA 릴리스를 배포할 때 대상 바이너리 버전의 JS 번들을 내려받아 binary patch의 base 번들로 사용합니다.
+
+다음 내용은 예시일 뿐이며, 각자의 배포 파이프라인에 맞는 방식으로 번들을 보관하세요.
+
+### Android 예시
+
+`./gradlew :app:assembleRelease`가 끝난 뒤 export 결과를 업로드합니다.
+
+```sh
 aws s3 cp --recursive \
   android/app/build/codepush/embedded-bundle/release \
   "s3://your-bucket/binaries/android/$BINARY_VERSION/"
+```
 
-# iOS - $BUILD_DIR는 빌드 안에서만 존재하므로, 파이프라인이 아는 경로로 export 위치를 지정한다
+### iOS 예시
+
+`$BUILD_DIR`는 빌드 안에서만 존재하므로, CI가 알고 있는 경로를 export 경로로 지정합니다.
+
+```sh
 export CODEPUSH_EXPORT_DIR="$PWD/codepush-export"
-xcodebuild -workspace ios/YourApp.xcworkspace -scheme YourApp -configuration Release archive # ...
+
+xcodebuild \
+  -workspace ios/YourApp.xcworkspace \
+  -scheme YourApp \
+  -configuration Release \
+  archive # ...
+
 aws s3 cp --recursive \
   "$CODEPUSH_EXPORT_DIR/Release-iphoneos" \
   "s3://your-bucket/binaries/ios/$BINARY_VERSION/"
 ```
 
-이후 patch를 배포할 때는 보관해 둔 export를 내려받아 번들 경로를 `--binary-bundle-path`에 전달합니다.
+## 3. binary patch 릴리스 배포하기
 
-```bash
-aws s3 cp --recursive "s3://your-bucket/binaries/android/1.0.0/" ./binary/
-npx code-push release -b 1.0.0 -v 1.0.1 -p android \
-                      --binary-bundle-path ./binary/index.android.bundle
+배포 대상 바이너리 버전의 JS 번들을 보관해둔 곳에서 내려받고, 해당 JS 번들의 경로를 `--binary-bundle-path`에 전달합니다.
+
+```sh
+aws s3 cp --recursive \
+  "s3://your-bucket/binaries/android/1.0.0/" \
+  ./binary/
+
+npx code-push release \
+  -b 1.0.0 \
+  -v 1.0.1 \
+  -p android \
+  --binary-bundle-path ./binary/index.android.bundle
 ```
 
-`release`는 export에 함께 담긴 `binary-patch-base.json` 기록으로 전달받은 base 번들이 맞는지 검증하기도 합니다. 자세한 내용은 [base 번들 검증](../cli/README.ko.md#base-번들-검증)을 참고하세요.
+`release` 명령은 JS 번들과 함께 보관했던 `binary-patch-base.json` 파일을 읽어 전달한 base 번들이 올바른지도 검증합니다. 자세한 내용은 [**base 번들 검증**](../cli/README.ko.md#base-번들-검증)을 참고하세요.
 
-## asset diff 아카이브
+## 4. asset diff 아카이브 배포하기
 
-binary patch로 배포한 릴리스는 **asset diff 아카이브**도 함께 담을 수 있습니다. 최근에 배포한 버전마다 하나씩입니다. diff 아카이브는 JS 번들의 patch, 기준이 된 버전에 아직 없는 asset, 삭제해야 하는 파일 목록 manifest만 담습니다. 클라이언트는 이미 설치한 기준 업데이트를 복사한 뒤 patch와 manifest를 적용하고, 결과적으로 full 아카이브와 똑같은 내용을 갖게 됩니다.
+binary patch를 배포할 때 이전 OTA 업데이트를 기준으로 한 asset diff 아카이브도 함께 배포할 수 있습니다. 최근 업데이트 N개에 대해 각각 asset diff 아카이브가 추가로 생성됩니다. (만약 asset diff 아카이브의 크기가 binary patch 아카이브보다 같거나 크면 배포되지는 않습니다.)
 
-클라이언트는 아래 순서로 아카이브를 시도하고, 설치할 수 있는 첫 번째 아카이브에서 멈춥니다.
+asset diff에는 다음만 포함됩니다.
 
-| 순서 | 아카이브 | 사용 조건 |
-|---|---|---|
-| 1 | asset diff | 클라이언트가 실행 중인 업데이트를 기준으로 릴리스가 diff를 만들어 둔 경우입니다. |
-| 2 | binary patch | 항상 쓸 수 있습니다. 모든 클라이언트가 가진 앱 바이너리의 번들을 기준으로 만들기 때문입니다. |
-| 3 | full | 항상 쓸 수 있습니다. 설치된 업데이트가 없어도 됩니다. |
+- JS 번들 binary patch
+- 기준 업데이트에 없던 새 asset 파일들
+- 삭제할 asset 파일 목록 manifest 파일
 
-이 순서에는 예외가 세 가지 있습니다.
-
-**모든 클라이언트가 셋을 다 시도하지는 않습니다.** 쓸 수 있는 asset diff가 없는 클라이언트는 binary patch에서 시작합니다. 앱 바이너리의 번들을 실행 중이거나, 새 릴리스가 diff를 만들지 않은 업데이트를 실행 중인 경우입니다.
-
-**asset diff가 실패해도 항상 binary patch로 넘어가지는 않습니다.** diff가 asset 영역에서 실패했다면 넘어갑니다. 설치된 업데이트와 병합하지 못했거나(`asset_merge_failed`), 병합된 내용이 package hash 검증에 실패한 경우(`package_verification_failed`)입니다. 서버가 diff의 URL에 400 이상으로 응답했을 때도 넘어갑니다. 두 아카이브는 서로 다른 URL에 있으니, diff를 받지 못했다고 해서 binary patch도 받지 못하리라 단정할 수 없습니다. 그 밖의 실패는 두 아카이브가 byte 단위로 똑같이 담고 있는 bundle patch에서 일어납니다. binary patch도 같은 방식으로 실패하므로 곧바로 full 아카이브를 내려받습니다.
-
-**연결이 실패하면 다운로드가 거기서 멈춥니다.** 다음 아카이브도 같은 네트워크 뒤에 있고 full 아카이브는 셋 중 가장 큽니다. 이어서 시도해 봐야 더 느리게 실패할 뿐이므로, 클라이언트는 연결 오류를 그대로 알립니다. 서버가 응답한 경우는 다릅니다. 한 아카이브의 404는 다음 아카이브를 건너뛸 이유가 되지 않습니다.
-
-`onUpdateArchiveResult`는 시도한 아카이브를 모두 보고합니다. [텔레메트리 콜백](telemetry-callbacks.ko.md#onupdatearchiveresult가-보고하는-내용)을 참고하세요.
+앱은 업데이트 다운로드 후 기준 OTA 업데이트를 복사한 뒤 JS 번들을 패치하고 불필요한 asset 파일들을 삭제합니다. 그 결과 남는 내용은 full 아카이브 업데이트와 동일합니다.
 
 ### 배포 조건
 
-diff 아카이브는 아래 세 조건이 모두 성립할 때만 배포됩니다.
+asset diff는 아래 조건이 모두 충족될 때만 배포됩니다.
 
-- binary patch 릴리스여야 합니다(`release --binary-bundle-path`).
-- `code-push.config.ts`가 `bundleDownloader`를 구현해야 합니다. CLI가 diff의 기준이 될 이전 릴리스를 내려받는 데 사용합니다.
-- `--diff-base-count`가 `0`보다 커야 합니다. 기본값은 `3`입니다.
+1. binary patch 릴리스여야 합니다. 즉, `release --binary-bundle-path`를 사용해야 합니다.
+2. `code-push.config.ts`에 `bundleDownloader`가 구현되어 있어야 합니다.
+3. `--diff-base-count` 옵션 값이 `0`보다 커야 합니다. 기본값은 `3`입니다.
+
+`bundleDownloader`는 CLI가 asset diff의 기준이 될 이전 업데이트를 내려받을 때 사용합니다.
 
 ```ts
 bundleDownloader: async (archive, platform, identifier = 'staging') => {
-    const downloadedFilePath = path.join(os.tmpdir(), archive.packageHash);
-    const storageKey = `bundles/${platform}/${identifier}/full-bundle/${archive.packageHash}`;
-    // storageKey를 스토리지(S3, Supabase, ...)에서 downloadedFilePath로 내려받는다
-    return { downloadedFilePath };
+  const downloadedFilePath = path.join(os.tmpdir(), archive.packageHash);
+  const storageKey =
+    `bundles/${platform}/${identifier}/full-bundle/${archive.packageHash}`;
+
+  // storageKey의 아카이브를 S3, Supabase 등의 저장소에서
+  // downloadedFilePath로 내려받도록 구현하세요.
+
+  // downloadedFilePath 경로를 반환하세요.
+  return { downloadedFilePath };
 },
 ```
 
-릴리스가 실제로 무엇을 배포하는지는 [asset diff archive](../cli/README.ko.md#asset-diff-archive)를 참고하세요.
+실제로 어떤 asset diff 아카이브가 생성되고 배포되는지는 [**asset diff archive**](../cli/README.ko.md#asset-diff-archive)를 참고하세요.
+
+## 업데이트 다운로드와 fallback 순서
+
+업데이트를 다운로드할 때 작은 아카이브부터 시도합니다.
+
+| 순서 | 아카이브 | 선택 조건 |
+| --- | --- | --- |
+| 1 | asset diff | 현재 실행 중인 OTA 업데이트를 기준으로 한 diff가 있는 경우 |
+| 2 | binary patch | asset diff를 사용할 수 없거나, asset 차이점 적용에 실패한 경우 |
+| 3 | full | binary patch를 사용할 수 없거나 패치 적용에 실패한 경우 |
+
+### asset diff를 건너뛰는 경우
+
+다음 경우에는 asset diff가 없으므로 binary patch부터 시도합니다.
+
+- 앱 바이너리에 내장된 번들을 실행 중인 경우 (첫 번째 OTA 업데이트)
+- 현재 OTA 업데이트를 기준으로 asset diff를 만들지 않은 경우
+
+### asset diff 실패 시 다음 아카이브를 선택하는 기준
+
+실패 원인에 따라 fallback 경로가 달라집니다.
+
+| 실패 상황 | 다음 동작 | 이유 |
+| --- | --- | --- |
+| `asset_merge_failed` | binary patch 시도 | 설치된 업데이트에 asset 차이를 적용하지 못함. 모든 asset을 받아 교체하는 방식은 성공할 수 있음 |
+| `package_verification_failed` | binary patch 시도 | asset diff로 병합한 결과의 최종 hash가 맞지 않음. 모든 asset을 받아 교체하는 방식은 성공할 수 있음 |
+| asset diff 다운로드 URL이 HTTP `400` 이상 응답 | binary patch 시도 | asset diff와 binary patch의 다운로드 URL은 각각 별개이므로, 하나를 받지 못했다고 다른 하나도 받을 수 없는 것은 아님 |
+| bundle patch 적용 실패 | full 아카이브 다운로드 | asset diff와 binary patch는 JS 번들에 동일한 patch를 수행하므로 binary patch로 fallback 해도 실패할 가능성이 높음 |
+| 네트워크 연결 오류 | fallback하지 않고 오류 보고 | 다음 방식 역시 동일한 네트워크를 사용하고, full 아카이브는 사이즈도 더 크므로 이어서 시도해도 더 느리게 실패할 가능성이 큼 |
+
+연결 오류와 서버 응답 오류는 다르게 처리합니다. 예를 들어 asset diff 다운로드 URL이 `404`를 반환한 경우에는 서버 연결은 성공한 상태이므로, 다음 수단인 binary patch나 full 아카이브를 건너뛸 이유가 없습니다.
+
+## 결과 관찰
+
+`onUpdateArchiveResult` 콜백은 앱이 시도한 모든 업데이트의 결과를 보고합니다. 실제로 어떤 아카이브가 선택되었는지, 어떤 이유로 fallback했는지 수집하려면 [**텔레메트리 콜백**](./telemetry-callbacks.ko.md#onupdatearchiveresult-이해하기)을 참고하세요.

--- a/docs/diff-updates.md
+++ b/docs/diff-updates.md
@@ -1,40 +1,59 @@
 # Diff Updates
 
-[한국어](diff-updates.ko.md)
+[한국어](./diff-updates.ko.md)
 
-A release can offer the client the difference between the update and a bundle the client
-already holds, in place of the whole thing. There are two kinds of difference, and an asset
-diff is only published on a release that carries a binary patch:
+By default, the `release` command publishes a **full archive** containing the entire update. Diff updates let clients download only the differences needed for an update.
 
-- a **binary patch**, computed against the JS bundle inside the app binary. Every client on
-  that binary version holds that bundle, so every one of them can use it.
-- an **asset diff**, computed against a recently released update. Only a client running that
-  update can use it, and it carries only the assets that update does not already have, where
-  the binary patch carries every asset.
+This feature is optional. Without any additional configuration, `release` publishes only the full archive. If a diff update is unavailable or cannot be applied, the app falls back to the full archive and installs the update unless the failure is a network connection error.
 
-A client that can use neither downloads the full archive, so a release installs either way.
-All of this is optional: with none of it set up, `release` publishes the full archive alone.
+## What archives are published?
 
-Publishing patches takes two things. Binary patches need the embedded bundle of every binary
-version you release against, which is what
-[Exporting the embedded bundle](#exporting-the-embedded-bundle) sets up. Asset diffs need
-that plus a `bundleDownloader` in `code-push.config.ts`, covered under
-[Asset diff archives](#asset-diff-archives). The patch generator itself has to be built
-once before the first patch release - see
-[Prerequisites: building the patch generator](../cli/README.md#prerequisites-building-the-patch-generator).
+| Archive | Compared against | Contents | Available when |
+| --- | --- | --- | --- |
+| full | Nothing | Entire update | Always |
+| binary patch | JS bundle embedded in the app binary | JS bundle diff and all assets | The client is running the target binary version |
+| asset diff | Previous OTA update | JS bundle diff, new assets, and a list of assets to delete | The client is running the base OTA update |
 
-## Exporting the embedded bundle
+### Binary patch
 
-A binary patch is the difference between the update and the JS bundle that is already
-inside the installed app, so releasing one means holding on to that bundle: the exact
-bytes the build you shipped to the store embedded.
+A binary patch is generated against the JS bundle embedded in the app binary published to the store.
 
-The library ships a hook for each platform that copies the freshly compiled bundle out of
-the build, together with a `binary-patch-base.json` record describing it.
+Every build for the same release target (binary version) must contain the same embedded bundle. Once you archive that embedded bundle, every update targeting the same binary version can provide a binary patch.
 
-**Android** - apply the Gradle script in your app module's `android/app/build.gradle`:
+### Asset diff
 
-```groovy
+An asset diff is generated against a previously published OTA update. Therefore, only an app running that base OTA update can use it.
+
+Unlike a binary patch, which contains every asset, an asset diff contains only assets absent from the base update. The smaller the asset difference between the base update and the new release, the smaller the asset diff will be.
+
+## What to prepare before you start
+
+Publishing diff updates requires the following:
+
+1. **Export embedded bundles for binary patches**
+
+   For every binary version you support, archive the exact JS bundle embedded in the binary published to the store.
+
+2. **Configure previous archive downloads for asset diffs**
+
+   To publish asset diffs as well, implement `bundleDownloader` in `code-push.config.ts`.
+
+You must also build the patch generator once before generating patches. See [**Prerequisites: building the patch generator**](../cli/README.md#prerequisites-building-the-patch-generator) for details.
+
+## 1. Export the embedded bundle
+
+A binary patch is the difference between a new update and the JS bundle already embedded in the app. You must therefore preserve the exact JS bundle bytecode embedded in the build published to the store.
+
+The library provides an export hook for each platform. After the bundle build finishes, the hook exports:
+
+- The Hermes-compiled JS bundle (bytecode)
+- A `binary-patch-base.json` file containing bundle metadata and verification values
+
+### Android
+
+Apply the Gradle script in your app module's `android/app/build.gradle`:
+
+```gradle
 apply plugin: "com.android.application"
 apply plugin: "com.facebook.react"
 
@@ -45,118 +64,165 @@ react {
 apply from: "../../node_modules/@bravemobile/react-native-code-push/android/codepush-export.gradle"
 ```
 
-The line can go anywhere in the file (if you use `ext.codePushExportDir`, set it before the
-`apply from:` line). Every variant that bundles JS then exports to
-`android/app/build/codepush/embedded-bundle/<variant>/` after it is bundled. Pass
-`-PcodePushExportDir=<path>` (or set `ext.codePushExportDir`) to export somewhere else; the
-`<variant>` directory is appended either way.
+The `apply from` line can go anywhere in the file.
 
-**iOS** - call the export script at the end of the **"Bundle React Native code and images"**
-build phase. In Xcode, open that phase
-in your app target's **Build Phases** tab and append the last line below to its script:
+After the JS bundle is built, it is exported to:
 
-```bash
+```text
+android/app/build/codepush/embedded-bundle/<variant>/
+```
+
+To use a different export path, choose one of the following:
+
+- Pass `-PcodePushExportDir=<path>` to Gradle
+- Set `ext.codePushExportDir`
+
+If you set `ext.codePushExportDir`, place it before the `apply from` line. In either case, the `<variant>` directory is appended to the path.
+
+### iOS
+
+In Xcode, open the app target's **Build Phases** tab and find the **Bundle React Native code and images** phase. Add the final line below to the end of the existing script:
+
+```sh
 /bin/sh -c "\"$WITH_ENVIRONMENT\" \"$REACT_NATIVE_XCODE\""
 
+# Add this line
 "$SRCROOT/../node_modules/@bravemobile/react-native-code-push/scripts/export-embedded-bundle.sh"
 ```
 
-The export lands in `$BUILD_DIR/codepush/embedded-bundle/$CONFIGURATION-$PLATFORM_NAME/`.
-Set the `CODEPUSH_EXPORT_DIR` environment variable to export somewhere else; the
-`$CONFIGURATION-$PLATFORM_NAME` directory is appended either way.
+The default export path is:
 
-> [!NOTE]
-> Applying these hooks automatically through the Expo config plugin (`app.plugin.js`) is
-> not implemented yet.
+```text
+$BUILD_DIR/codepush/embedded-bundle/$CONFIGURATION-$PLATFORM_NAME/
+```
 
-### Archiving the export per binary release
+To use a different export path, set the `CODEPUSH_EXPORT_DIR` environment variable. The `$CONFIGURATION-$PLATFORM_NAME` directory is still appended to the path.
 
-Whatever pipeline builds your store binary should keep that build's export somewhere
-durable, organized by binary version, so a later release can fetch the bundle that matches
-the binary it targets:
+> **Note:** The Expo config plugin (`app.plugin.js`) does not currently apply this hook automatically.
 
-```bash
-# Android, after ./gradlew :app:assembleRelease
+## 2. Archive exports per binary release
+
+The CI pipeline that builds your store binary must archive the exported JS bundle by binary version.
+
+When publishing a later OTA release, download the JS bundle for the target binary version and use it as the binary patch base bundle.
+
+The following examples are only a reference. Archive the bundles in whatever way fits your deployment pipeline.
+
+### Android example
+
+Upload the export after `./gradlew :app:assembleRelease` finishes:
+
+```sh
 aws s3 cp --recursive \
   android/app/build/codepush/embedded-bundle/release \
   "s3://your-bucket/binaries/android/$BINARY_VERSION/"
+```
 
-# iOS - point the export at a path the pipeline knows, since $BUILD_DIR only exists inside the build
+### iOS example
+
+Because `$BUILD_DIR` exists only during the build, set the export directory to a path known to your CI pipeline:
+
+```sh
 export CODEPUSH_EXPORT_DIR="$PWD/codepush-export"
-xcodebuild -workspace ios/YourApp.xcworkspace -scheme YourApp -configuration Release archive # ...
+
+xcodebuild \
+  -workspace ios/YourApp.xcworkspace \
+  -scheme YourApp \
+  -configuration Release \
+  archive # ...
+
 aws s3 cp --recursive \
   "$CODEPUSH_EXPORT_DIR/Release-iphoneos" \
   "s3://your-bucket/binaries/ios/$BINARY_VERSION/"
 ```
 
-To release a patch later, download the export and pass the bundle's path to
-`--binary-bundle-path`:
+## 3. Publish a binary patch release
 
-```bash
-aws s3 cp --recursive "s3://your-bucket/binaries/android/1.0.0/" ./binary/
-npx code-push release -b 1.0.0 -v 1.0.1 -p android \
-                      --binary-bundle-path ./binary/index.android.bundle
+Download the JS bundle for the target binary version from your archive and pass its path to `--binary-bundle-path`:
+
+```sh
+aws s3 cp --recursive \
+  "s3://your-bucket/binaries/android/1.0.0/" \
+  ./binary/
+
+npx code-push release \
+  -b 1.0.0 \
+  -v 1.0.1 \
+  -p android \
+  --binary-bundle-path ./binary/index.android.bundle
 ```
 
-`release` also uses the `binary-patch-base.json` record to verify the base bundle it was
-handed - see [Verifying the base bundle](../cli/README.md#verifying-the-base-bundle) for
-details.
+The `release` command reads the `binary-patch-base.json` file archived with the JS bundle and verifies that the supplied base bundle is correct. See [**Verifying the base bundle**](../cli/README.md#verifying-the-base-bundle) for details.
 
-## Asset diff archives
+## 4. Publish asset diff archives
 
-A release published with a binary patch can carry **asset diff archives** as well - one per
-recently released version. A diff archive holds the patch of the JS bundle, only the assets
-that version does not already have, and a manifest of the files it has to drop. The client
-copies the update it already has installed, applies those, and ends up holding exactly the
-contents of the full archive.
+When publishing a binary patch, you can also publish asset diff archives against previous OTA updates. An asset diff archive is generated for each of the N most recent updates. It is not published if its size is greater than or equal to the binary patch archive.
 
-A client tries the archives in this order and stops at the first one it can install:
+An asset diff contains only:
 
-| Order | Archive | Available when |
-|---|---|---|
-| 1 | Asset diff | the release was diffed against the update the client is running. |
-| 2 | Binary patch | always. It is built against the bundle in the app binary, which every client has. |
-| 3 | Full | always. It needs nothing installed. |
+- The JS bundle binary patch
+- New asset files absent from the base update
+- A manifest listing asset files to delete
 
-There are three exceptions to this order.
+After downloading the update, the app copies the base OTA update, patches the JS bundle, and deletes unnecessary asset files. The resulting contents are identical to the full archive update.
 
-**Not every client tries all three.** One with no asset diff to use - it is running the
-bundle in the app binary, or an update this release was not diffed against - starts at the
-binary patch.
+### Publishing conditions
 
-**A failed asset diff does not always reach the binary patch.** It does when the diff failed
-on its asset side: the merge with the installed update failing (`asset_merge_failed`), or the
-merged contents failing the package hash (`package_verification_failed`). It also does when
-the server answered the diff's URL with a status of 400 or above. The two archives are at
-URLs of their own, so a diff that could not be fetched is no reason to expect the binary
-patch cannot be either. Anything else the diff fails on lives in the bundle patch both
-archives carry byte for byte. The binary patch would fail there the same way, so the client
-goes straight to the full archive.
+An asset diff is published only when all of the following conditions are met:
 
-**A failed connection stops the download.** The next archive is behind the same network,
-and the full one is the largest of the three, so trying it would only fail again more
-slowly. The client reports the connection error instead. A server that answered is
-different: a 404 on one archive is no reason to skip the next.
+1. The release is a binary patch release created with `release --binary-bundle-path`.
+2. `bundleDownloader` is implemented in `code-push.config.ts`.
+3. `--diff-base-count` is greater than `0`. The default is `3`.
 
-`onUpdateArchiveResult` reports every archive that was tried - see
-[Telemetry callbacks](telemetry-callbacks.md#what-onupdatearchiveresult-reports).
-
-### Enabling them
-
-Diff archives are published only when all three of these hold:
-
-- the release is a binary patch release (`release --binary-bundle-path`),
-- `code-push.config.ts` implements `bundleDownloader`, so the CLI can fetch the earlier releases to diff against,
-- `--diff-base-count` is greater than `0` (it defaults to `3`).
+The CLI uses `bundleDownloader` to download previous updates that serve as asset diff bases.
 
 ```ts
 bundleDownloader: async (archive, platform, identifier = 'staging') => {
-    const downloadedFilePath = path.join(os.tmpdir(), archive.packageHash);
-    const storageKey = `bundles/${platform}/${identifier}/full-bundle/${archive.packageHash}`;
-    // fetch storageKey from your storage (S3, Supabase, ...) to downloadedFilePath
-    return { downloadedFilePath };
+  const downloadedFilePath = path.join(os.tmpdir(), archive.packageHash);
+  const storageKey =
+    `bundles/${platform}/${identifier}/full-bundle/${archive.packageHash}`;
+
+  // Download the archive at storageKey from S3, Supabase, or another
+  // storage provider to downloadedFilePath.
+
+  // Return the downloadedFilePath.
+  return { downloadedFilePath };
 },
 ```
 
-See [Asset diff archives](../cli/README.md#asset-diff-archives) for what the release
-publishes.
+See [**Asset diff archives**](../cli/README.md#asset-diff-archives) for details about which asset diff archives are generated and published.
+
+## Update download and fallback order
+
+When downloading an update, the app tries the smallest archive first.
+
+| Order | Archive | Selected when |
+| --- | --- | --- |
+| 1 | asset diff | A diff exists against the OTA update currently running |
+| 2 | binary patch | The asset diff is unavailable or applying the asset differences fails |
+| 3 | full | The binary patch is unavailable or applying the patch fails |
+
+### When asset diff is skipped
+
+The app starts with the binary patch when no asset diff is available, including when:
+
+- The app is running the bundle embedded in the app binary (the first OTA update)
+- No asset diff was generated against the current OTA update
+
+### Choosing the next archive after an asset diff failure
+
+The fallback path depends on the failure:
+
+| Failure | Next action | Reason |
+| --- | --- | --- |
+| `asset_merge_failed` | Try the binary patch | The asset differences could not be applied to the installed update. Replacing all assets may still succeed |
+| `package_verification_failed` | Try the binary patch | The final hash of the contents merged from the asset diff does not match. Replacing all assets may still succeed |
+| The asset diff download URL returns HTTP `400` or higher | Try the binary patch | The asset diff and binary patch use separate download URLs, so failure to download one does not mean the other is unavailable |
+| Applying the bundle patch fails | Download the full archive | The asset diff and binary patch apply the same JS bundle patch, so falling back to the binary patch is likely to fail as well |
+| Network connection error | Report the error without falling back | The next option uses the same network, and the full archive is larger, so another attempt would likely fail more slowly |
+
+Connection errors and server response errors are handled differently. For example, a `404` response from the asset diff download URL means the server was reached, so there is no reason to skip the next option—the binary patch or full archive.
+
+## Observing results
+
+The `onUpdateArchiveResult` callback reports the result of every update the app tried. To collect which archive was selected and why fallback occurred, see [**Telemetry callbacks**](./telemetry-callbacks.md#what-onupdatearchiveresult-reports).

--- a/docs/telemetry-callbacks.ko.md
+++ b/docs/telemetry-callbacks.ko.md
@@ -1,119 +1,158 @@
 # 텔레메트리 콜백
 
-[English](telemetry-callbacks.md)
+[English](./telemetry-callbacks.md)
 
-`CodePushOptions`는 업데이트가 수행한 일을 보고하는 선택적 콜백을 받습니다. 이 콜백은 순전히 관찰을 위한 것이며 그 외의 역할은 없습니다. 라이브러리는 보고된 내용을 저장하거나 전송하지 않으므로, 텔레메트리에 기록하려면 앱에서 직접 전송해야 합니다. 콜백을 등록하지 않아도 업데이트 동작은 달라지지 않으며, 콜백이 예외를 던져도 해당 업데이트를 실패시키지 않고 콘솔에 기록합니다.
+`CodePushOptions`는 업데이트의 진행 결과를 관찰할 수 있는 선택적 콜백을 제공합니다.
 
-다른 모든 옵션과 함께 각 옵션의 세부 내용을 확인하려면 [`CodePushOptions`](api-js.md#codepushoptions)를 참고하세요.
+콜백은 **관찰 전용**입니다.
 
-## 콜백
+- 라이브러리는 콜백 데이터를 저장하거나 전송하지 않습니다. 텔레메트리에 남기려면 앱에서 직접 전송해야 합니다.
+- 콜백을 등록해도 업데이트 동작은 바뀌지 않습니다.
+- 콜백이 예외를 던져도 업데이트는 실패하지 않습니다.
 
-| 콜백 | 호출 시점 | 전달값 |
-|---|---|---|
-| `onDownloadStart` | 사용 가능한 업데이트의 다운로드가 시작될 때 | `(label)` |
-| `onDownloadSuccess` | 사용 가능한 업데이트의 다운로드가 완료될 때. 설치는 이후에 이뤄지므로, 업데이트를 설치할 수 있다는 뜻은 아닙니다. | `(label)` |
-| `onUpdateArchiveResult` | binary patch로 배포된 업데이트가 다운로드된 뒤, 설치되기 전 | `(label, result)` |
-| `onUpdateSuccess` | 성공 상태를 확정하는 [`notifyAppReady`](api-js.md#codepushnotifyappready) 호출을 기준으로, 설치된 업데이트가 정상 실행됐을 때 | `(label)` |
-| `onUpdateRollback` | 설치된 업데이트가 실행에 실패해 이전 버전으로 롤백될 때 | `(label)` |
-| `onRolloutSkipped` | 기기가 최신 릴리스의 활성 rollout 범위 밖이라 업데이트 검사에서 해당 릴리스를 후보에서 제외할 때 | `(label)` |
-| `onSyncError` | sync가 [`SyncStatus.UNKNOWN_ERROR`](api-js.md#syncstatus) 상태로 종료될 때 | `(label, error)` |
+다른 옵션까지 함께 확인하려면 `CodePushOptions`를 참고하세요.
 
-`label`은 보고 대상 릴리스입니다. 릴리스가 결정되기 전에 sync가 실패하면 `onSyncError`에는 대신 `"unknown"`이 전달됩니다.
+## 어떤 시점에 어떤 콜백이 호출되나요?
 
-> [!NOTE]
-> 타입 정의에서 `onRolloutSkipped`는 두 번째 `error` 매개변수를 선언하지만, 런타임은 항상 `label`만 전달합니다.
+| 콜백 | 호출 시점 | 전달값 | 주의할 점 |
+| --- | --- | --- | --- |
+| `onDownloadStart` | 사용 가능한 업데이트 다운로드를 시작할 때 | `(label)` | 다운로드 자체의 시작을 의미합니다. |
+| `onDownloadSuccess` | 사용 가능한 업데이트 다운로드를 마쳤을 때 | `(label)` | 아직 설치 또는 정상 실행이 보장된 것은 아닙니다. |
+| `onUpdateArchiveResult` | binary patch / asset diff 업데이트 다운로드가 끝난 뒤, 설치 전에 | `(label, result)` | 어떤 아카이브를 사용했고 patch fallback이 있었는지 확인합니다. |
+| `onUpdateSuccess` | 설치한 업데이트가 실행되고 `notifyAppReady`로 성공을 확정했을 때 | `(label)` | 실제 업데이트 성공을 기록할 시점입니다. |
+| `onUpdateRollback` | 설치한 업데이트 실행에 실패해 이전 버전으로 롤백할 때 | `(label)` | 다운로드 성공이나 설치 성공과는 별개입니다. |
+| `onRolloutSkipped` | 기기가 활성 rollout 범위 밖이어서 최신 릴리스를 후보에서 제외할 때 | `(label)` | 해당 릴리스가 이 기기에 배포되지 않았음을 뜻합니다. |
+| `onSyncError` | `sync()`가 `SyncStatus.UNKNOWN_ERROR`로 끝날 때 | `(label, error)` | 실패 원인은 `error.message`가 아니라 `error.code`로 분류하세요. |
 
-## `error`가 담고 있는 것
+`label`은 보고 대상 릴리스입니다. (예시: `"1.0.3"`) 릴리스가 결정되기 전에 `sync()`가 실패하면 `onSyncError`에는 `"unknown"`이 전달됩니다.
 
-리포트는 메시지가 아니라 `error.code`로 묶으세요. 메시지는 iOS에서 현지화되고 Android에서는 예외 자체의 문구입니다.
+> **참고:** `onRolloutSkipped`의 타입 정의에는 두 번째 `error` 매개변수가 존재하지만, 실제로는 아무것도 전달하지 않아 항상 `undefined` 값을 갖습니다.
 
-| 플랫폼 | `error.code` | 예 |
-|---|---|---|
-| iOS | [`NSURLError`](https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes) 코드를 문자열로, CodePush가 직접 던진 오류는 `-1` | `"-1005"`, 연결이 끊김 |
-| Android | 실패의 카테고리 | `"CODE_PUSH_NETWORK"`, 연결이 끊김 |
+## 오류를 기록하는 방법
 
-Android 카테고리는 다음과 같습니다.
+오류는 `error.message`가 아니라 `error.code`로 묶어 기록하세요.
 
-| Code | 뜻 | 다시 받아 볼 가치 |
-|---|---|---|
-| `CODE_PUSH_NETWORK` | 연결이 끊겼거나, 시간이 초과됐거나, 열리지 않았습니다. | 네트워크가 돌아오면 있음 |
-| `CODE_PUSH_HTTP` | 서버가 400 이상으로 응답했습니다. 상태 코드는 메시지에 있습니다. | 상태 코드에 따라 다름 |
-| `CODE_PUSH_INTEGRITY` | 다운로드한 내용의 hash가 릴리스의 package hash와 다르거나, 그 안에 앱이 찾는 이름의 JS 번들이 없습니다. | 없음 |
-| `CODE_PUSH_UNKNOWN` | 그 밖의 경우입니다. | 알 수 없음 |
+메시지는 iOS에서는 현지화된 메시지가 전달될 수 있고, Android에서는 원본 에러의 문구를 포함합니다. 반면 `error.code`는 집계와 알림 조건으로 활용하기에 더 적합합니다.
 
-`CodePush.sync()`도 같은 오류로 거절되므로, 반환값을 기다리는 호출자에게는 이 콜백이 필요 없습니다.
+| 플랫폼 | `error.code` 형식 | 예시 |
+| --- | --- | --- |
+| iOS | `NSURLError` 코드를 문자열로 전달합니다. CodePush가 직접 던진 오류는 `-1`입니다. | `"-1005"`: 연결 끊김 |
+| Android | 실패 원인을 나타내는 카테고리입니다. | `"CODE_PUSH_NETWORK"` |
 
-## 등록
+### Android 오류 코드
 
-[앱에 CodePush 적용하기](../README.md#4-codepush-ify-your-app)의 `CodePush({ ... })` 래퍼에 콜백을 전달하면, `checkFrequency` 값과 무관하게 직접 호출한 `CodePush.sync()`를 포함한 모든 sync에서 실행됩니다.
+| 코드 | 의미 | 다시 다운로드할 가치 |
+| --- | --- | --- |
+| `CODE_PUSH_NETWORK` | 연결이 끊겼거나, 시간 초과됐거나, 연결을 열 수 없습니다. | 네트워크가 복구된 뒤에는 다시 시도할만 함 |
+| `CODE_PUSH_HTTP` | 서버가 HTTP `400` 이상으로 응답했습니다. 상태 코드는 메시지에 있습니다. | 상태 코드에 따라 달라짐 |
+| `CODE_PUSH_INTEGRITY` | 다운로드 내용의 hash가 릴리스 `package hash` 값과 다르거나, 앱이 찾는 이름의 JS 번들이 없습니다. | 없음 |
+| `CODE_PUSH_UNKNOWN` | 그 밖의 오류입니다. | 알 수 없음 |
 
-```typescript
+`CodePush.sync()`도 같은 오류로 거절됩니다. 따라서 `sync()`의 리턴값을 직접 기다리는 호출자는 `onSyncError` 콜백을 별도로 등록할 필요가 없습니다.
+
+## 콜백 등록하기
+
+앱에 CodePush를 적용할 때 `CodePush({ ... })` 래퍼에 콜백을 전달합니다.
+
+이렇게 등록한 콜백은 `checkFrequency` 값과 관계없이, 앱이 직접 호출한 `CodePush.sync()`를 포함한 모든 `sync()`에서 실행됩니다.
+
+```ts
 export default CodePush({
-  checkFrequency: CodePush.CheckFrequency.MANUAL, // or something else
-  releaseHistoryFetcher: releaseHistoryFetcher,
+  checkFrequency: CodePush.CheckFrequency.MANUAL,
+  releaseHistoryFetcher,
   onUpdateSuccess: (label) => {
-    // Send it to your own telemetry, if you want it there.
+    // 필요하면 자체 텔레메트리로 전송합니다.
   },
   onUpdateArchiveResult: (label, result) => {
-    // Send it to your own telemetry, if you want it there.
+    // 필요하면 자체 텔레메트리로 전송합니다.
   },
 })(MyApp);
 ```
 
-`onUpdateArchiveResult`는 개별 `sync()` 호출에도 전달할 수 있는 유일한 콜백입니다. 여기에 전달하면 그 호출에 한해 래퍼에 등록한 콜백을 덮어씁니다. 예를 들어 특정 sync의 결과만 별도로 태그할 때 사용할 수 있습니다.
+### 특정 `sync()`에만 콜백 등록하기
 
-```typescript
+`onUpdateArchiveResult`는 개별 `sync()` 호출에도 추가로 전달할 수 있는 유일한 텔레메트리 콜백입니다.
+
+개별 호출에 전달한 콜백은 그 호출에 한해 래퍼에 등록한 `onUpdateArchiveResult`를 덮어씁니다. 예를 들어 특정 동작에서 발생한 결과만 별도 태그로 기록할 때 사용할 수 있습니다.
+
+```ts
 CodePush.sync({
   onUpdateArchiveResult: (label, result) => {
-    // Send it to your own telemetry, if you want it there.
+    // 이 sync 호출의 결과만 기록합니다.
   },
 });
 ```
 
-## `onUpdateArchiveResult`가 보고하는 내용
+## `onUpdateArchiveResult` 이해하기
 
-binary patch로 배포한 릴리스는 full 아카이브 대신 다운로드할 수 있는 patch 아카이브를 제공합니다. 아카이브의 종류와 릴리스에 포함되는 조건은 [asset diff 아카이브](diff-updates.ko.md#asset-diff-아카이브)를 참고하세요. 이 콜백은 업데이트를 어떤 아카이브에서 다운로드했는지와, 업데이트에 쓰이지 못한 나머지 아카이브에 어떤 일이 있었는지를 보고합니다.
+Diff 업데이트라면 full 아카이브 대신 patch 아카이브를 먼저 시도할 수 있습니다.
+
+- `asset-diff`: 이전 OTA 업데이트를 기준으로 한 차이
+- `binary-patch`: 앱 바이너리에 내장된 번들을 기준으로 한 차이
+- `full`: 업데이트 전체
+
+`onUpdateArchiveResult`는 다음을 알려 줍니다.
+
+1. 적용할 업데이트가 어떤 patch 아카이브를 사용해 만들어졌는지
+2. patch 적용을 포기하고 full 아카이브를 받았는지
+3. 각 patch 시도에 걸린 시간과 fallback 이유
+
+`full` 아카이브 자체는 `attempts`에 포함되지 않습니다.
 
 ### `UpdateArchiveResult`
 
 | 필드 | 타입 | 설명 |
-|---|---|---|
-| `status` | `"applied" \| "fallback"` | patch 아카이브 중 하나로 업데이트를 만들었는지, 아니면 full 아카이브를 다운로드해야 했는지 나타냅니다. |
-| `archive` | `UpdateArchive` | 마지막 시도 아카이브입니다. 업데이트를 가져온 아카이브이거나, 마지막으로 포기한 아카이브입니다. |
-| `fallbackReason` | `ArchiveFallbackReason` | full 아카이브를 다운로드해야 했던 이유입니다. `"applied"`일 때는 없으며, 마지막 시도가 어느 applier도 이유 코드를 부여하지 못한 오류로 끝났을 때도 없습니다. |
-| `totalDurationMs` | `number` | 첫 번째 아카이브 다운로드 시작부터 마지막 시도가 끝날 때까지 patch 경로 전체에 걸린 시간입니다. fallback 뒤에 이어지는 full 다운로드 시간은 포함하지 않습니다. |
-| `attempts` | `UpdateArchiveAttempt[]` | 시도한 모든 아카이브를 시도한 순서대로 담습니다. full 아카이브는 포함하지 않습니다. |
+| --- | --- | --- |
+| `status` | `"applied" \| "fallback"` | patch 아카이브로 업데이트를 만들었는지, 또는 full 아카이브가 필요했는지 나타냅니다. |
+| `archive` | `UpdateArchive` | 업데이트를 만든 아카이브 또는 마지막으로 포기한 patch 아카이브입니다. |
+| `fallbackReason` | `ArchiveFallbackReason` | full 아카이브가 필요했던 이유입니다. `status`가 `"applied"`라면 정보는 없습니다. 마지막 시도가 reason 코드를 만들지 못한 오류로 끝난 경우에도 없을 수 있습니다. |
+| `totalDurationMs` | `number` | 첫 patch 다운로드 시작부터 마지막 patch 시도가 끝날 때까지의 시간입니다. fallback 뒤 full 다운로드 시간은 포함하지 않습니다. |
+| `attempts` | `UpdateArchiveAttempt[]` | 시도한 모든 patch 아카이브를 시도 순서대로 담습니다. full 아카이브는 포함하지 않습니다. |
 
 `UpdateArchive`는 `"binary-patch"` 또는 `"asset-diff"`입니다.
 
 ### `UpdateArchiveAttempt`
 
 | 필드 | 타입 | 설명 |
-|---|---|---|
-| `archive` | `UpdateArchive` | 이 시도에서 다운로드한 아카이브입니다. |
-| `fallbackReason` | `ArchiveFallbackReason` | 이 아카이브를 포기한 이유입니다. 업데이트를 가져온 시도에는 없습니다. |
-| `durationMs` | `number` | 성공·실패와 관계없이 이 시도에 걸린 시간입니다. |
-| `applyDurationMs` | `number` | applier가 이 아카이브의 patch로 번들을 복원하는 데 걸린 시간입니다. 번들을 복원하기 전에 시도가 끝나면 없습니다. |
+| --- | --- | ---|
+| `archive` | `UpdateArchive` | 이 시도에서 내려받은 아카이브입니다. |
+| `fallbackReason` | `ArchiveFallbackReason` | 이 아카이브를 포기한 이유입니다. 업데이트를 가져온 시도에는 필드가 없습니다. |
+| `durationMs` | `number` | 성공/실패와 관계없이 이 시도에 걸린 시간입니다. |
+| `applyDurationMs` | `number` | 이 아카이브의 patch로 번들을 복원하는 데 걸린 시간입니다. 번들 복원 전에 시도가 끝나면 필드가 없습니다. |
 
-대부분의 다운로드에는 시도가 하나만 남습니다. asset diff가 asset 영역에서 실패하면 두 번째 시도가 생깁니다. 설치된 업데이트와 병합하지 못했거나(`asset_merge_failed`), 병합된 내용이 package hash 검증에 실패한 경우(`package_verification_failed`)입니다. 이때 클라이언트는 모든 asset을 포함하고 설치된 업데이트에 의존하지 않는 binary patch를 시도합니다. 반면 두 아카이브가 공유하는 bundle patch에서 asset diff가 실패하면 binary patch도 같은 방식으로 실패하므로 건너뛰고 곧바로 full 아카이브를 다운로드합니다.
+### `attempts` 배열을 읽는 방법
 
-### `fallbackReason`
+대부분의 다운로드에는 시도 내역 하나만 남습니다.
 
-모든 플랫폼의 applier는 같은 이유 코드를 보고하므로, 실행 플랫폼과 관계없이 rollout을 판단할 수 있습니다.
+asset diff가 asset 차이점 적용 범주에서 실패하거나 asset diff URL이 HTTP 400 이상의 응답을 반환하면 두 번째 시도가 생길 수 있습니다.
 
-| 이유 | 설명 |
-|---|---|
+1. `asset-diff`를 시도합니다.
+2. 설치된 업데이트와 병합하지 못했거나(`asset_merge_failed`), 병합 결과가 package hash 검증에 실패했거나(`package_verification_failed`), asset diff URL이 HTTP 400 이상의 응답을 반환하면 `binary-patch`를 시도합니다.
+3. `binary-patch`도 적용할 수 없으면 full 아카이브를 다운로드합니다.
+
+반대로 asset diff와 binary patch가 공유하는 bundle patch 과정에서 실패한 경우에는 binary patch도 같은 방식으로 실패할 것이 확실합니다. 이때는 binary patch를 건너뛰고 곧바로 full 아카이브를 다운로드합니다.
+
+## `fallbackReason`
+
+양 플랫폼에서 fallback 사유 코드를 보고합니다. 따라서 플랫폼별 오류 문구를 해석하지 않고도 동일한 기준으로 telemetry를 집계할 수 있습니다.
+
+| 사유 | 설명 |
+| --- | --- |
 | `base_bundle_unavailable` | 앱 바이너리 안의 번들을 열거나 읽을 수 없습니다. |
-| `base_hash_mismatch` | 앱 바이너리 안의 번들이 patch를 생성할 때 기준으로 삼은 번들과 다릅니다. |
+| `base_hash_mismatch` | 앱 바이너리 안의 번들이 patch 생성 시 기준으로 사용한 번들과 다릅니다. |
 | `invalid_manifest` | manifest가 없거나 잘못됐거나, 아카이브 밖의 경로를 가리키거나, 허용 범위를 초과한 작업을 요청합니다. |
 | `unsupported_format` | 클라이언트가 적용할 수 없는 형식 또는 codec으로 patch가 생성됐습니다. |
-| `patch_apply_failed` | applier가 patch 적용을 거부했거나, 복원한 번들을 쓸 수 없습니다. |
-| `target_verification_failed` | 복원한 번들이 manifest가 약속한 내용과 다릅니다. |
-| `asset_merge_failed` | asset diff를 생성할 때 기준으로 삼았던 설치된 업데이트와 병합할 수 없습니다. |
-| `package_verification_failed` | patch로 복원한 업데이트가 복원 뒤 검증에 실패했습니다. |
+| `patch_apply_failed` | applier가 patch 적용을 거부했거나, 적용 결과물 번들을 사용할 수 없습니다. |
+| `target_verification_failed` | 적용 결과물 번들이 manifest가 약속한 내용과 다릅니다. |
+| `asset_merge_failed` | asset diff의 기준이 된 설치된 업데이트와 병합할 수 없습니다. |
+| `package_verification_failed` | patch 적용 결과물이 검증에 실패했습니다. |
 
-### fallback은 업데이트 실패가 아닙니다
+## fallback은 업데이트 실패가 아닙니다
 
-대신 full 아카이브를 다운로드하고 평소처럼 설치합니다. 이 콜백이 전달받는 내용은 업데이트 동작에 영향을 주지 않습니다.
+`status: "fallback"`은 patch 경로를 포기했다는 뜻이지 업데이트 자체가 실패했다는 뜻은 아닙니다.
 
-다만 fallback은 `downloadProgressCallback`에도 나타납니다. fallback 이후 이어지는 각 다운로드는 자체 progress stream을 가지며, 각각의 `totalBytes`를 기준으로 `receivedBytes`를 다시 0부터 계산합니다.
+이 때 앱은 full 아카이브 다운로드와 설치를 시도합니다. 이 콜백이 받은 결과도 업데이트 동작에 영향을 주지 않습니다.
+
+fallback은 `downloadProgressCallback`에도 나타납니다. fallback 뒤에 시작하는 각 다운로드는 독립된 progress stream을 가지므로, `receivedBytes`는 각 아카이브의 `totalBytes`를 기준으로 새로 계산됩니다. 따라서 fallback이 가능한 릴리스에서 progress를 기록할 때는 전체 업데이트의 누적 진행률이 아니라 **아카이브별 진행률**로 해석해야 합니다.
+
+만약 progress bar UI나 진행률 퍼센트를 화면에 표시한다면, fallback 발생 시점에 진행률이 이전보다 낮은 값으로 되돌아갔다가 다시 차오를 수 있습니다.

--- a/docs/telemetry-callbacks.md
+++ b/docs/telemetry-callbacks.md
@@ -1,145 +1,158 @@
 # Telemetry Callbacks
 
-[한국어](telemetry-callbacks.ko.md)
+[한국어](./telemetry-callbacks.ko.md)
 
-`CodePushOptions` takes optional callbacks that report what an update did. They exist to be
-observed and nothing more: the library neither stores what they report nor sends it
-anywhere, so an app that wants any of it in its telemetry sends it itself. Registering none
-changes nothing about how updates behave, and a callback that throws is logged to the
-console rather than failing the update it is reporting on.
+`CodePushOptions` provides optional callbacks for observing an update's progress and result.
 
-For the per-option reference, alongside every other option, see
-[`CodePushOptions`](api-js.md#codepushoptions).
+The callbacks are **for observation only**.
 
-## The callbacks
+- The library does not store or send callback data. Your app must send the data itself to record it in telemetry.
+- Registering callbacks does not change update behavior.
+- An update does not fail if a callback throws.
 
-| Callback | Called when | Receives |
-|---|---|---|
-| `onDownloadStart` | the download of an available update begins | `(label)` |
-| `onDownloadSuccess` | the download of an available update has completed. The install happens afterwards, so this says nothing about whether the update could be installed | `(label)` |
-| `onUpdateArchiveResult` | an update published with a binary patch has been downloaded, before it is installed | `(label, result)` |
-| `onUpdateSuccess` | an installed update has run successfully, as of the [`notifyAppReady`](api-js.md#codepushnotifyappready) that marks it successful | `(label)` |
-| `onUpdateRollback` | an installed update failed to run and was rolled back to the previous version | `(label)` |
-| `onRolloutSkipped` | the device falls outside the latest release's active rollout, so the update check leaves that release out of the candidates | `(label)` |
-| `onSyncError` | the sync ends in the [`SyncStatus.UNKNOWN_ERROR`](api-js.md#syncstatus) state | `(label, error)` |
+See `CodePushOptions` for the other available options.
 
-`label` is the release the report is about. `onSyncError` passes `"unknown"` instead when
-the sync failed before a release was resolved.
+## When is each callback called?
 
-> [!NOTE]
-> The typings declare a second `error` parameter on `onRolloutSkipped`, but the runtime only
-> ever passes the label.
+| Callback | Called when | Receives | Notes |
+| --- | --- | --- | --- |
+| `onDownloadStart` | The download of an available update begins | `(label)` | Indicates only that the download has started. |
+| `onDownloadSuccess` | The download of an available update finishes | `(label)` | Installation and successful execution are not guaranteed yet. |
+| `onUpdateArchiveResult` | A binary patch or asset diff update has finished downloading, before installation | `(label, result)` | Shows which archive was used and whether patch fallback occurred. |
+| `onUpdateSuccess` | An installed update runs and is confirmed successful through `notifyAppReady` | `(label)` | This is the point to record an actual update success. |
+| `onUpdateRollback` | An installed update fails to run and rolls back to the previous version | `(label)` | This is separate from download or installation success. |
+| `onRolloutSkipped` | The device is outside the active rollout, so the latest release is excluded from the candidates | `(label)` | The release was not deployed to this device. |
+| `onSyncError` | `sync()` ends with `SyncStatus.UNKNOWN_ERROR` | `(label, error)` | Classify the cause by `error.code`, not `error.message`. |
 
-## What `error` carries
+`label` is the release being reported. (Example: `"1.0.3"`) If `sync()` fails before a release is resolved, `onSyncError` receives `"unknown"`.
 
-Group reports by `error.code`, not by the message: the message is localized on iOS and is
-the exception's own words on Android.
+> **Note:** The type definition for `onRolloutSkipped` includes a second `error` parameter, but the runtime passes no value for it, so it is always `undefined`.
 
-| Platform | `error.code` | Example |
-|---|---|---|
-| iOS | the [`NSURLError`](https://developer.apple.com/documentation/foundation/1508628-url_loading_system_error_codes) code as a string, or `-1` for an error CodePush raised itself | `"-1005"`, the connection dropped |
-| Android | the category of the failure | `"CODE_PUSH_NETWORK"`, the connection dropped |
+## How to record errors
 
-Android categories:
+Group errors by `error.code`, not `error.message`.
 
-| Code | Means | Worth downloading again |
-|---|---|---|
-| `CODE_PUSH_NETWORK` | The connection dropped, timed out, or never opened. | Once the network is back |
-| `CODE_PUSH_HTTP` | The server answered with a status of 400 or above. The status is in the message. | Depends on the status |
-| `CODE_PUSH_INTEGRITY` | The downloaded contents do not hash to the release's package hash, or hold no JS bundle by the name the app looks for. | No |
-| `CODE_PUSH_UNKNOWN` | Anything else. | Unknown |
+On iOS, the message may be localized. On Android, it includes the original error text. By contrast, `error.code` is better suited for aggregation and alert conditions.
 
-`CodePush.sync()` rejects with the same error, so a caller that awaits it does not need
-this callback.
+| Platform | `error.code` format | Example |
+| --- | --- | --- |
+| iOS | An `NSURLError` code as a string. Errors raised directly by CodePush use `-1`. | `"-1005"`: connection lost |
+| Android | A category that represents the cause of the failure. | `"CODE_PUSH_NETWORK"` |
 
-## Registering them
+### Android error codes
 
-Pass them to the `CodePush({ ... })` wrapper from
-["CodePush-ify" Your App](../README.md#4-codepush-ify-your-app). They run for every sync,
-whatever the `checkFrequency` is, including the `CodePush.sync()` calls you make yourself.
+| Code | Meaning | Worth downloading again |
+| --- | --- | --- |
+| `CODE_PUSH_NETWORK` | The connection was lost, timed out, or could not be opened. | Worth retrying after the network recovers |
+| `CODE_PUSH_HTTP` | The server responded with an HTTP status of `400` or above. The message contains the status code. | Depends on the status code |
+| `CODE_PUSH_INTEGRITY` | The downloaded contents do not match the release's `package hash`, or do not contain a JS bundle with the name the app expects. | No |
+| `CODE_PUSH_UNKNOWN` | Any other error. | Unknown |
 
-```typescript
+`CodePush.sync()` also rejects with the same error. Therefore, callers that directly await the result of `sync()` do not need to register `onSyncError` separately.
+
+## Registering callbacks
+
+Pass the callbacks to the `CodePush({ ... })` wrapper when applying CodePush to your app.
+
+Callbacks registered this way run for every `sync()`, regardless of `checkFrequency`, including `CodePush.sync()` calls made directly by the app.
+
+```ts
 export default CodePush({
-  checkFrequency: CodePush.CheckFrequency.MANUAL, // or something else
-  releaseHistoryFetcher: releaseHistoryFetcher,
+  checkFrequency: CodePush.CheckFrequency.MANUAL,
+  releaseHistoryFetcher,
   onUpdateSuccess: (label) => {
-    // Send it to your own telemetry, if you want it there.
+    // Send to your own telemetry if needed.
   },
   onUpdateArchiveResult: (label, result) => {
-    // Send it to your own telemetry, if you want it there.
+    // Send to your own telemetry if needed.
   },
 })(MyApp);
 ```
 
-`onUpdateArchiveResult` is the only callback that you can also pass to an individual
-`sync()` call. Passing it there overrides the registered one for that call - to tag the
-result of one particular sync, for instance.
+### Registering a callback for a specific `sync()`
 
-```typescript
+`onUpdateArchiveResult` is the only telemetry callback that can also be passed to an individual `sync()` call.
+
+A callback passed to an individual call overrides the `onUpdateArchiveResult` registered on the wrapper for that call. For example, you can use it to record results from a specific action with a separate tag.
+
+```ts
 CodePush.sync({
   onUpdateArchiveResult: (label, result) => {
-    // Send it to your own telemetry, if you want it there.
+    // Record only the result of this sync call.
   },
 });
 ```
 
-## What `onUpdateArchiveResult` reports
+## Understanding `onUpdateArchiveResult`
 
-A release published with a binary patch offers the client patch archives to download in
-place of the full one. See
-[Asset diff archives](diff-updates.md#asset-diff-archives) for what those are and when a
-release carries them. This callback reports which of them the download came from, and what
-happened to the ones it did not.
+For a diff update, the client can try a patch archive before the full archive.
+
+- `asset-diff`: The difference from a previous OTA update
+- `binary-patch`: The difference from the bundle embedded in the app binary
+- `full`: The entire update
+
+`onUpdateArchiveResult` tells you:
+
+1. Which patch archive was used to build the update that will be applied
+2. Whether the client gave up applying a patch and downloaded the full archive
+3. How long each patch attempt took and why it fell back
+
+The `full` archive itself is not included in `attempts`.
 
 ### `UpdateArchiveResult`
 
 | Field | Type | Description |
-|---|---|---|
-| `status` | `"applied" \| "fallback"` | Whether one of the patch archives produced the update, or the full archive had to be downloaded instead. |
-| `archive` | `UpdateArchive` | The archive of the last attempt: the one the update came from, or the last one given up on. |
-| `fallbackReason` | `ArchiveFallbackReason` | Why the full archive had to be downloaded. Absent on `"applied"`, and when the last attempt ended in an error no applier has a word for. |
-| `totalDurationMs` | `number` | How long the whole patch path took, from the first archive starting to download to the last attempt being finished with. The full download that follows a fallback is not part of it. |
-| `attempts` | `UpdateArchiveAttempt[]` | Every archive that was tried, in the order it was tried. The full archive is never among them. |
+| --- | --- | --- |
+| `status` | `"applied" \| "fallback"` | Whether a patch archive produced the update or the full archive was required. |
+| `archive` | `UpdateArchive` | The archive that produced the update, or the last patch archive that was abandoned. |
+| `fallbackReason` | `ArchiveFallbackReason` | Why the full archive was required. There is no value when `status` is `"applied"`. It may also be absent if the last attempt ended with an error that did not produce a reason code. |
+| `totalDurationMs` | `number` | The time from the start of the first patch download until the final patch attempt finished. It does not include the full download that follows a fallback. |
+| `attempts` | `UpdateArchiveAttempt[]` | Every patch archive attempted, in order. It does not include the full archive. |
 
 `UpdateArchive` is `"binary-patch"` or `"asset-diff"`.
 
 ### `UpdateArchiveAttempt`
 
 | Field | Type | Description |
-|---|---|---|
-| `archive` | `UpdateArchive` | Which archive this attempt downloaded. |
-| `fallbackReason` | `ArchiveFallbackReason` | Why this archive was given up on. Absent for the attempt the update came from. |
-| `durationMs` | `number` | How long this attempt ran, whichever way it ended. |
-| `applyDurationMs` | `number` | How long the applier took to rebuild the bundle from this archive's patch. Absent when the attempt ended before the bundle was restored. |
+| --- | --- | --- |
+| `archive` | `UpdateArchive` | The archive downloaded for this attempt. |
+| `fallbackReason` | `ArchiveFallbackReason` | Why this archive was abandoned. The field is absent on the attempt that produced the update. |
+| `durationMs` | `number` | How long this attempt took, whether it succeeded or failed. |
+| `applyDurationMs` | `number` | How long it took to restore the bundle from this archive's patch. The field is absent if the attempt ended before the bundle was restored. |
 
-Most downloads leave a single attempt. A second one appears when an asset diff failed on its
-asset side - the merge with the installed update failing (`asset_merge_failed`), or the
-merged contents failing the package hash (`package_verification_failed`). The client then
-tries the binary patch, which carries every asset and depends on nothing installed. A diff
-that failed in the bundle patch both archives carry skips the binary patch and goes straight
-to the full archive, because it would fail there the same way.
+### How to read the `attempts` array
 
-### `fallbackReason`
+Most downloads record only one attempt.
 
-Every platform's applier reports the same words, so a rollout can be judged by them
-whichever platform it is running on.
+A second attempt may be recorded if the asset diff fails while applying the asset differences, or if the asset diff URL returns an HTTP status of 400 or above.
+
+1. The client tries `asset-diff`.
+2. It tries `binary-patch` if the asset diff could not be merged with the installed update (`asset_merge_failed`), the merged result failed package hash verification (`package_verification_failed`), or the asset diff URL returned an HTTP status of 400 or above.
+3. If `binary-patch` also cannot be applied, the client downloads the full archive.
+
+By contrast, if the shared bundle patch step fails for an asset diff, the binary patch is certain to fail in the same way. The client skips the binary patch and downloads the full archive immediately.
+
+## `fallbackReason`
+
+Both platforms report fallback reason codes. This allows telemetry to be aggregated using the same criteria without interpreting platform-specific error messages.
 
 | Reason | Description |
-|---|---|
+| --- | --- |
 | `base_bundle_unavailable` | The bundle inside the app binary could not be opened or read. |
-| `base_hash_mismatch` | The bundle inside the app binary is not the one the patch was computed against. |
-| `invalid_manifest` | The manifest is missing, malformed, points outside the archive, or asks for too much. |
-| `unsupported_format` | The patch was produced by a format or a codec this client cannot apply. |
-| `patch_apply_failed` | The applier refused the patch, or the restored bundle could not be written. |
-| `target_verification_failed` | The restored bundle is not the one the manifest promised. |
-| `asset_merge_failed` | The asset diff could not be merged with the installed update it was built against. |
-| `package_verification_failed` | The update restored from the patch did not pass the checks that follow the restore. |
+| `base_hash_mismatch` | The bundle inside the app binary differs from the bundle used as the base when the patch was generated. |
+| `invalid_manifest` | The manifest is missing or malformed, points outside the archive, or requests an operation beyond the permitted limits. |
+| `unsupported_format` | The patch was generated in a format or with a codec that the client cannot apply. |
+| `patch_apply_failed` | The applier rejected the patch, or the resulting bundle could not be used. |
+| `target_verification_failed` | The resulting bundle does not match what the manifest specified. |
+| `asset_merge_failed` | The asset diff could not be merged with the installed update it was based on. |
+| `package_verification_failed` | The result of applying the patch failed verification. |
 
-### A fallback is not a failed update
+## A fallback is not an update failure
 
-The update is downloaded in full instead and installed as usual. Nothing about the update
-depends on what this callback is told.
+`status: "fallback"` means the patch path was abandoned, not that the update itself failed.
 
-A fallback does show in `downloadProgressCallback`, though: each download after one reports
-a progress stream of its own, counting `receivedBytes` from zero again against its own
-`totalBytes`.
+The app then attempts to download and install the full archive. The result received by this callback does not affect update behavior.
+
+A fallback also appears in `downloadProgressCallback`. Each download that starts after a fallback has an independent progress stream, so `receivedBytes` is calculated afresh against each archive's `totalBytes`. For releases that can fall back, interpret recorded progress as **per-archive progress**, not cumulative progress for the entire update.
+
+If a progress bar or percentage is displayed in the UI, it may move back to a lower value when fallback occurs and then fill again.


### PR DESCRIPTION
## Summary
- Rewrite the Korean and English diff update guides around archive selection, setup, release, and fallback behavior
- Expand the telemetry callback docs with error categories, archive attempt data, and progress fallback semantics
- Update CLI documentation links to the renamed sections

## Test plan
- `npm run jest`
- `git diff --check`